### PR TITLE
feat: OAuth2 및 JWT를 활용한 인증 로직 구현 (#15)

### DIFF
--- a/backend/src/main/java/app/signbell/backend/config/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/app/signbell/backend/config/JwtAuthenticationFilter.java
@@ -1,0 +1,107 @@
+package app.signbell.backend.config;
+
+
+import app.signbell.backend.util.CookieProperties;
+import app.signbell.backend.util.JwtTokenProvider;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Collections;
+
+/**
+ * JWT 인증 필터.
+ *
+ * 이 필터는 매 요청마다 한 번(OncePerRequest) 실행됩니다.
+ * - 토큰 추출: 우선순위 1) Authorization 헤더의 Bearer 토큰, 2) HTTP-Only 쿠키(ACCESS_TOKEN)
+ * - 토큰 검증: 서명/만료를 검증합니다.
+ * - 컨텍스트 설정: 유효한 토큰이면 {@link SecurityContextHolder}에 인증 객체를 저장합니다.
+ * - 비유효/부재: 아무런 설정 없이 다음 필터로 흐름을 넘깁니다.
+ *
+ * 주의사항
+ * - Refresh Token은 이 필터에서 사용하지 않습니다(재발급 전용이므로 별도 엔드포인트에서 처리).
+ * - 이미 인증 컨텍스트가 있는 경우(체인 상 다른 필터 등) 재설정하지 않습니다.
+ *
+ * @author 송민재
+ * @since 2025-10-14
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CookieProperties cookieProperties;
+
+    /**
+     * 요청에서 액세스 토큰을 찾아 검증 후, 인증 컨텍스트를 구성합니다.
+     *
+     * @param request  HTTP 요청
+     * @param response HTTP 응답
+     * @param filterChain 다음 필터로 전달하기 위한 체인
+     */
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        // 토큰이 존재하고 유효하며, 아직 인증 컨텍스트가 비어있을 때만 설정합니다.
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)
+                && SecurityContextHolder.getContext().getAuthentication() == null) {
+            Claims claims = jwtTokenProvider.getClaims(token);
+            String subject = claims.getSubject(); // 일반적으로 사용자 식별자
+
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    subject,
+                    null,
+                    Collections.emptyList()
+            );
+            ((UsernamePasswordAuthenticationToken) authentication)
+                    .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * 요청에서 액세스 토큰을 추출합니다.
+     *
+     * 우선순위
+     * 1) Authorization 헤더의 Bearer 스킴: "Authorization: Bearer <token>"
+     * 2) HTTP-Only 쿠키: 이름은 설정값(cookie.access-token-name)
+     *
+     * @param request HTTP 요청
+     * @return 액세스 토큰(없으면 null)
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookieProperties.getAccessTokenName().equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/config/OAuth2FailureHandler.java
+++ b/backend/src/main/java/app/signbell/backend/config/OAuth2FailureHandler.java
@@ -1,0 +1,55 @@
+package app.signbell.backend.config;
+
+
+import app.signbell.backend.util.AppProperties;
+import app.signbell.backend.util.CookieUtil;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * OAuth2 로그인 실패 시 실행되는 핸들러.
+ *
+ * 동작
+ * 1) 실패 원인을 로깅하고, 사용자 친화적 에러 메시지 구성
+ * 2) 혹시 남아있을 수 있는 토큰 쿠키를 정리
+ * 3) 프론트엔드 에러 페이지(또는 로그인 페이지)로 리다이렉트하며 메시지를 쿼리로 전달
+ *
+ * - 실패 테스트방법: .env의 카카오 secret key를 잘못 입력하고 카카오 로그인
+ * /oauth2/authorization/kakao 로 접근
+ *
+ * @author 송민재
+ * @since 2025-10-14
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+
+    private final CookieUtil cookieUtil;
+    private final AppProperties appProperties;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        String rawMessage = exception.getMessage() == null ? "oauth2_login_failed" : exception.getMessage();
+        log.warn("OAuth2 authentication failed: {}", rawMessage);
+
+        // 쿠키 정리 (있다면)
+        cookieUtil.deleteAccessTokenCookie(response);
+        cookieUtil.deleteRefreshTokenCookie(response);
+
+        String encodedMsg = URLEncoder.encode(rawMessage, StandardCharsets.UTF_8);
+        String baseUrl = appProperties.getOauth2FailureRedirectUrl();
+        String redirect = baseUrl.contains("?") ? baseUrl + "&error=" + encodedMsg : baseUrl + "?error=" + encodedMsg;
+        response.sendRedirect(redirect);
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/config/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/app/signbell/backend/config/OAuth2SuccessHandler.java
@@ -1,0 +1,63 @@
+package app.signbell.backend.config;
+
+
+import app.signbell.backend.util.AppProperties;
+import app.signbell.backend.util.CookieUtil;
+import app.signbell.backend.util.JwtTokenProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * OAuth2 로그인 성공 시 실행되는 핸들러.
+ *
+ * 동작 순서
+ * 1) 인증 주체(OAuth2User)에서 식별자(subject)를 가져온다
+ * 2) Access/Refresh JWT를 생성한다
+ * 3) 두 토큰을 HTTP-Only 쿠키에 담아 응답 헤더(Set-Cookie)로 내려준다
+ * 4) 프론트엔드 애플리케이션 URL로 안전하게 리다이렉트한다
+ *
+ * 보안 포인트
+ * - 토큰을 URL 쿼리로 노출하지 않고, HTTP-Only 쿠키로만 전달한다 → XSS로부터 보호
+ * - SameSite/Secure/Domain 등 쿠키 옵션은 CookieUtil에서 일괄 적용한다(yml 참조)
+ *
+ * @author 송민재
+ * @since 2025-10-14
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CookieUtil cookieUtil;
+    private final AppProperties appProperties;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        // 1) OAuth2 인증 주체에서 고유 식별자(subject) 획득
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        String subject = String.valueOf(oAuth2User.getName());
+
+        // 2) Access/Refresh 토큰 생성 (클레임은 최소화)
+        String accessToken = jwtTokenProvider.createAccessToken(subject, Map.of());
+        String refreshToken = jwtTokenProvider.createRefreshToken(subject);
+
+        // 3) 토큰을 HTTP-Only 쿠키로 설정 (URL 노출 금지)
+        cookieUtil.addAccessTokenCookie(response, accessToken);
+        cookieUtil.addRefreshTokenCookie(response, refreshToken);
+
+        // 4) 프론트엔드 애플리케이션으로 리다이렉트
+        String redirectUrl = appProperties.getOauth2SuccessRedirectUrl();
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/app/signbell/backend/config/SecurityConfig.java
@@ -1,0 +1,114 @@
+package app.signbell.backend.config;
+
+
+import app.signbell.backend.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
+
+/**
+ * Spring Security 설정 파일.
+ *
+ * - OAuth2 로그인 핸들러, JWT 필터 및 CORS/CSRF/세션 정책을 정의합니다.
+ * - 세션을 사용하지 않는 STATELESS 방식으로 설정됩니다.
+ * - 요청 권한 정책: PUBLIC_ENDPOINTS는 허용, 나머지는 인증이 필요합니다.
+ * - JWT 인증 필터({@link JwtAuthenticationFilter})가 가장 먼저 동작하도록 설정합니다.
+ *
+ * @author 송민재
+ * @since 2025-10-14
+ */
+@Configuration
+@EnableWebSecurity  // 커스텀 시큐리티 설정파일이라는 의미
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+
+    // 허용할 엔드포인트 목록을 배열로 따로 관리
+    private static final String[] PUBLIC_ENDPOINTS = {
+            "/**", // 프로젝트 초기 설정이므로 임시로 모든 엔드포인트 허용, 이후에 조정 필요
+            "/",
+            "/health",
+            "/api/auth/**",
+            "/oauth2/**",
+            "/login/oauth2/**",
+            // 앞으로 추가될 퍼블릭 엔드포인트를 여기에 나열합니다.
+            "/media/**",
+            "/images/**",
+
+    };
+
+    // 시큐리티 필터체인 빈을 등록
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, JwtAuthenticationFilter jwtAuthenticationFilter) throws Exception {
+
+        // 커스텀 보안 설정
+        http
+                // 프론트엔드 개발 서버 및 지정된 오리진만 허용
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                // JWT 쿠키 기반이므로 CSRF는 사용하지 않음
+                .csrf(csrf -> csrf.disable())
+                // 완전한 무상태(Stateless)로 동작
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                // 기본 제공 로그인/기본 인증은 사용하지 않음
+                .formLogin(form -> form.disable())
+                .httpBasic(basic -> basic.disable())
+                // H2 콘솔 접근을 위해 동일 출처 iframe 허용
+                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
+                // 엔드포인트 권한 정책: 퍼블릭 → 허용, 나머지 → 인증 필요
+                .authorizeHttpRequests(authz -> authz
+                        // 배열에 담긴 엔드포인트에 대해 접근을 허용
+                        .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
+                        .anyRequest().authenticated()
+                )
+                // OAuth2 로그인 활성화 및 사용자 정보 서비스/성공/실패 핸들러 연결
+                .oauth2Login(oauth -> oauth
+                        .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))
+                        .successHandler(oAuth2SuccessHandler)
+                        .failureHandler(oAuth2FailureHandler)
+                )
+                // 인증 실패 시 401 Unauthorized 반환
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint((req, res, e) -> res.sendError(401))
+                )
+                // UsernamePasswordAuthenticationFilter 전에 JWT 필터 동작
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+
+        return http.build();
+
+    }
+
+    /**
+     * CORS 설정.
+     *
+     * - 개발 중에는 Vite/CRA 개발 서버를 허용합니다.
+     * - 운영 배포 시, 실제 프론트엔드 도메인(예: https://app.example.com)을 추가하세요.
+     * - 크리덴셜(withCredentials) 전송을 허용합니다.
+     */
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:5173", "http://127.0.0.1:5173"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+
+}

--- a/backend/src/main/java/app/signbell/backend/controller/AuthController.java
+++ b/backend/src/main/java/app/signbell/backend/controller/AuthController.java
@@ -1,0 +1,82 @@
+package app.signbell.backend.controller;
+
+
+import app.signbell.backend.util.CookieUtil;
+import app.signbell.backend.util.JwtTokenProvider;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * 인증 관련 엔드포인트 컨트롤러.
+ *
+ * - /api/auth/refresh: 쿠키의 Refresh Token을 검증하고 새 Access Token 쿠키를 내려줍니다.
+ * - 이 컨트롤러는 HTTP-Only 쿠키 기반 재발급만 담당하며, 바디/헤더로 토큰을 주고받지 않습니다.
+ */
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+@Slf4j
+public class AuthController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CookieUtil cookieUtil;
+
+    /**
+     * Refresh Token을 사용해 Access Token을 재발급합니다.
+     *
+     * 요청의 Refresh Token을 확인하고, 유효한 경우 새로운 Access Token을 생성한 뒤
+     * 응답에 쿠키로 추가합니다. Refresh Token이 없거나 유효하지 않을 경우
+     * 401 Unauthorized 상태를 반환합니다.
+     *
+     * @param request  클라이언트 요청 객체로, Refresh Token이 포함된 쿠키를 읽습니다.
+     * @param response 서버 응답 객체로, 새로운 Access Token이 포함된 쿠키를 설정합니다.
+     * @return 성공 시 204 No Content, 실패 시 401 Unauthorized 상태를 포함한 응답을 반환합니다.
+     *
+     * @author 송민재
+     * @since 2025-10-14
+     */
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        log.debug("[AuthController] /api/auth/refresh called, remoteAddr={}", request.getRemoteAddr());
+        String refreshToken = cookieUtil.readRefreshToken(request); // 쿠키에서 Refresh Token 조회
+        if (refreshToken == null || !jwtTokenProvider.validateToken(refreshToken)) { // 유효성 체크 실패
+            log.warn("[AuthController] Refresh token missing or invalid");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build(); // 401 반환
+        }
+
+        Claims claims = jwtTokenProvider.getClaims(refreshToken); // Refresh Token의 클레임 파싱
+        String subject = claims.getSubject(); // 사용자 식별자(subject)
+
+        String newAccessToken = jwtTokenProvider.createAccessToken(subject, Map.of()); // 새 Access Token 생성
+        cookieUtil.addAccessTokenCookie(response, newAccessToken); // Access Token 쿠키로 설정
+        log.info("[AuthController] Access token reissued for subject={}", subject);
+        return ResponseEntity.noContent().build(); // 204 No Content 반환
+    }
+
+    /**
+     * 로그아웃: Access/Refresh 쿠키를 삭제합니다.
+     *
+     * @param response 서버 응답 객체로, 삭제된 쿠키 정보를 클라이언트에 전달합니다.
+     * @return 204 No Content 상태를 포함한 응답을 반환합니다.
+     *
+     * @author 송민재
+     * @since 2025-10-14
+     */
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletResponse response) {
+        cookieUtil.deleteAccessTokenCookie(response);
+        cookieUtil.deleteRefreshTokenCookie(response);
+        log.info("[AuthController] Logged out: cleared auth cookies");
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/entity/User.java
+++ b/backend/src/main/java/app/signbell/backend/entity/User.java
@@ -15,11 +15,17 @@ import java.time.LocalDateTime;
  * 사용자 ID, 닉네임, 이메일, 로그인 방식, 가입 시간, 수정 시간, 누적 점수 등의 속성을 포함하고 있습니다.
  *
  * 이 클래스는 사용자 데이터의 저장, 조회 및 관리를 위해 사용됩니다.
- * @author 고동현
- * @since 2025-10-13
+ * @author 송민재
+ * @since 2025-10-14
  */
 @Entity
-@Table(name = "user")
+//@Table(name = "user")
+@Table(
+        name = "user",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_provider_id", columnNames = {"provider", "provider_id"})
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
@@ -41,15 +47,42 @@ public class User {
     /**
      * 이메일
      */
-    @Column(nullable = false, unique = true)
+    @Column(unique = true)
     private String email;
+
+    /**
+     * 프로필 이미지 URL
+     */
+    @Column
+    private String profileImageUrl;
+
+    /**
+     * OAuth 공급자 (로그인 방식)
+     * LoginMethod ENUM을 사용하도록 타입 변경
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private LoginMethod provider;
+
+    /**
+     * OAuth 공급자에서 부여한 ID (누락 필드 추가)
+     */
+    @Column(name = "provider_id", nullable = false)
+    private String providerId;
+
+    /**
+     * 약관 동의 여부 (누락 필드 추가)
+     */
+    @Column(nullable = false)
+    private Boolean agree;
+
 
     /**
      * 로그인 방식
      */
-    @Enumerated(EnumType.STRING)
+    /*@Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private LoginMethod loginMethod;
+    private LoginMethod loginMethod;*/
 
     /**
      * 사용자 누적 점수
@@ -70,12 +103,45 @@ public class User {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
-    @Builder
+    /*@Builder
     public User(String nickname, String email, LoginMethod loginMethod) {
         this.nickname = nickname;
         this.email = email;
         this.loginMethod = loginMethod;
         this.totalScore = 0L; // 빌더 생성 시 기본값 0으로 초기화
+    }*/
+    /**
+     * User 객체를 빌더 패턴을 사용하여 생성하는 생성자.
+     * 사용자 정보를 초기화하며 입력값이 null인 경우 기본값을 설정합니다.
+     * 객체를 생성할 때, 기본값이 설정된 항목을 패턴에 기재하지 않으면 자동으로 기본값이 설정됩니다.
+     *
+     * @param nickname 사용자의 닉네임
+     * @param profileImageUrl 사용자의 프로필 이미지 URL
+     * @param provider 사용자가 가입한 OAuth 제공자 (예: Google, Facebook 등)
+     * @param providerId OAuth 제공자에서 부여한 사용자 ID
+     * @param agree 약관 동의 여부 (기본값: false)
+     *
+     * @author 송민재
+     * @since 2025-10-14
+     */
+    @Builder
+    public User(
+            String nickname
+            , String profileImageUrl
+            , LoginMethod provider
+            , String providerId
+            , String email
+            , Boolean agree
+    ) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.provider = provider; // LoginMethod가 할당됨
+        this.providerId = providerId;
+        this.email = email;
+
+        // 값이 null일 경우 기본값으로 대체
+        this.agree = agree != null ? agree : false;
+        this.totalScore = 0L; // 빌더에서 totalScore 초기화
     }
 
     /**
@@ -84,5 +150,32 @@ public class User {
      */
     public void updateTotalScore(int score) {
         this.totalScore += score;
+    }
+
+    /**
+     * 사용자 프로필 정보를 업데이트합니다.
+     * - 닉네임: null이 아닌 경우에만 변경됩니다.
+     * - 프로필 이미지 URL: 전달된 값으로 그대로 설정됩니다(Null 허용).
+     *
+     * @param nickname          변경할 닉네임(Null이면 기존 값 유지)
+     * @param profileImageUrl   변경할 프로필 이미지 URL(Null 가능)
+     *
+     * @author 송민재
+     * @since 2025-10-14
+     */
+    public void updateProfile(String nickname, String profileImageUrl) {
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    /**
+     * 사용자의 동의 상태 업데이트 편의 메서드
+     * @author 송민재
+     * @since 2025-10-14
+     */
+    public void updateAgreement() {
+        this.agree = true;
     }
 }

--- a/backend/src/main/java/app/signbell/backend/repository/UserRepository.java
+++ b/backend/src/main/java/app/signbell/backend/repository/UserRepository.java
@@ -1,8 +1,11 @@
 
 package app.signbell.backend.repository;
 
+import app.signbell.backend.entity.LoginMethod;
 import app.signbell.backend.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 /**
  * UserRepository 인터페이스는 사용자 정보(User 엔티티)에 대한 데이터베이스 CRUD 작업을 처리하기 위해
@@ -17,4 +20,15 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @since 2025-10-12
  */
 public interface UserRepository extends JpaRepository<User, Long> {
+    //    Optional<User> findByProviderAndProviderId(String provider, String providerId);
+
+    /**
+     * Stiring -> LoginMetiond로 provider의 자료형 변환
+     * 주어진 로그인 제공업체와 해당 제공업체 ID를 기반으로 사용자를 조회합니다.
+     *
+     * @param provider 로그인에 사용된 외부 제공업체 (예: Google, Kakao, Naver 등)의 종류
+     * @param providerId 해당 제공업체가 부여한 사용자 고유 ID
+     * @return 조건에 맞는 사용자(User) 객체를 감싸는 Optional. 사용자가 발견되지 않으면 Optional.empty()를 반환
+     */
+    Optional<User> findByProviderAndProviderId(LoginMethod provider, String providerId);
 }

--- a/backend/src/main/java/app/signbell/backend/service/CustomOAuth2UserService.java
+++ b/backend/src/main/java/app/signbell/backend/service/CustomOAuth2UserService.java
@@ -1,0 +1,163 @@
+package app.signbell.backend.service;
+
+import app.signbell.backend.entity.LoginMethod;
+import app.signbell.backend.entity.User;
+import app.signbell.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * OAuth2 사용자 정보를 로드하고 우리 도메인 사용자로 동기화하는 서비스.
+ *
+ * 동작 개요
+ * 1) 공급자(registrationId)에 따라 응답 스키마를 구분
+ * 2) 사용자 식별자(providerId), 이메일/닉네임/프로필 이미지를 추출
+ * 3) 기존 사용자면 프로필을 업데이트, 없으면 신규로 저장
+ * 4) ROLE_USER 권한의 DefaultOAuth2User를 반환 (name은 우리 플랫폼의 User ID)
+ *
+ * 주의
+ * - 카카오는 응답 구조가 중첩되어 있어 안전 캐스팅과 널 처리(safeStr, coalesce)를 사용합니다.
+ * - 반환되는 OAuth2User의 getName()은 우리 플랫폼의 User ID를 반환합니다.
+ *
+ * 테스트 URL
+ * - http://localhost:9000/oauth2/authorization/kakao
+ *
+ * @author 송민재
+ * @since 2025-10-14
+ */
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 공급자에서 사용자 정보를 조회하고, 우리 DB와 동기화한 뒤 OAuth2User를 반환합니다.
+     *
+     * 절차
+     * - super.loadUser(...)로 공급자 사용자 정보 조회
+     * - registrationId(google|kakao)로 공급자를 식별
+     * - 공급자별 스키마에 맞게 주요 필드 추출 (providerId, nickname, profileImageUrl)
+     * - 기존 사용자 → 프로필 업데이트, 신규 사용자 → 저장
+     * - nameAttributeKey를 공급자별로 맞춰 DefaultOAuth2User 구성
+     * - getName()은 우리 플랫폼의 User ID를 반환하도록 오버라이드
+     */
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // registrationId는 yml 파일의 registration 뒤에 나오는 값
+        // 예시) client.registration.kakao -> kakao, client.registration.google -> google
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        // registrationId가 카카오가 아닌경우 -> 이상한 provider 감지, error throw
+        if (!"kakao".equalsIgnoreCase(registrationId)) {
+            throw new OAuth2AuthenticationException("Unsupported provider: " + registrationId);
+        }
+
+//        String provider = registrationId;
+        // String 대신 LoginMethod ENUM을 사용
+        LoginMethod loginProvider = LoginMethod.valueOf(registrationId.toUpperCase()); // "kakao" -> KAKAO
+
+        // 사용자 정보를 JSON으로 받지 않아도
+        // Spring Security가 대신 받아와서 편하게 사용할 수 있도록 Map 형태로 제공해주는 사용자 정보 묶음
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+        String providerId;
+        String nickname;
+        String profileImageUrl;
+        String email;
+
+        // 위에서 provider 검사 이미 완료.
+        // Kakao 응답 스키마: https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
+        providerId = String.valueOf(attributes.get("id"));
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.getOrDefault("kakao_account", Collections.emptyMap());
+
+        // 이메일 추출 로직 추가
+        email = safeStr(kakaoAccount.get("email"));
+        if (email == null) {
+            // 이메일 미동의 시 임시 이메일 부여 또는 예외 처리 로직 추가 필요
+            email = providerId + "@" + registrationId + ".com"; // 임시 처리 예시
+        }
+
+        // 닉네임이 없을 경우, 기본값 할당 로직 추가
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.getOrDefault("profile", Collections.emptyMap());
+        String tempNickname = safeStr(profile.get("nickname"));
+
+        // 닉네임이 없으면 'user_' + providerId 와 같은 임시 닉네임 부여
+        if (tempNickname == null || tempNickname.isBlank()) {
+            nickname = "user_" + providerId;
+        } else {
+            nickname = tempNickname;
+        }
+
+        profileImageUrl = safeStr(profile.get("profile_image_url"));
+
+        // 유저가 이미 있음 -> 프로필 업데이트, 없음 -> 새로 생성
+        // findByProviderAndProviderId의 첫 인자가 LoginMethod로 변경
+        Optional<User> existing = userRepository.findByProviderAndProviderId(loginProvider, providerId);
+        User user = existing.map(u -> {
+            u.updateProfile(nickname, profileImageUrl);
+            return u;
+        }).orElseGet(() -> User.builder()
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+//                .provider(provider)
+                // LoginMethod ENUM을 User 엔티티의 provider 필드에 저장
+                .provider(loginProvider)
+                .providerId(providerId)
+                // agree는 빌더에서 기본값 false로 자동 처리
+                .build());
+
+        // ✅ 중요: save() 호출 후 생성된 ID를 가져옴
+        User savedUser = userRepository.save(user);
+        Long internalUserId = savedUser.getId(); // 우리 플랫폼의 자동 생성된 User ID
+
+        // ✅ DefaultOAuth2User를 반환하되, getName()을 우리 플랫폼의 userId로 오버라이드
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority("ROLE_USER")),
+                attributes,
+                resolveNameAttributeKey(registrationId)
+        ) {
+            @Override
+            public String getName() {
+                // 우리 플랫폼의 User ID를 반환 (JWT subject로 사용됨)
+                return String.valueOf(internalUserId);
+            }
+        };
+    }
+
+    /**
+     * Spring Security가 principal의 name으로 사용할 attribute key를 공급자별로 반환합니다.
+     * 향후 공급자 추가 확장을 고려하여 검증 로직을 유지함
+     * - Google: sub (OpenID Connect 표준 subject)
+     * - Kakao: id
+     */
+    private String resolveNameAttributeKey(String registrationId) {
+        String id = registrationId == null ? "" : registrationId.toLowerCase();
+        return switch (id) {
+//            case "google" -> "sub";
+            case "kakao" -> "id";
+            default -> "id";
+        };
+    }
+
+    /**
+     * 객체를 null-safe하게 문자열로 변환합니다. null이면 null을 반환합니다.
+     */
+    private String safeStr(Object v) {
+        return v == null ? null : String.valueOf(v);
+    }
+
+}

--- a/backend/src/main/java/app/signbell/backend/util/.gitkeep
+++ b/backend/src/main/java/app/signbell/backend/util/.gitkeep
@@ -1,2 +1,0 @@
-# This file exists to preserve directory structure in Git
-# `Git`에서 디렉토리 구조를 유지하기 위한 파일입니다.

--- a/backend/src/main/java/app/signbell/backend/util/AppProperties.java
+++ b/backend/src/main/java/app/signbell/backend/util/AppProperties.java
@@ -1,0 +1,15 @@
+package app.signbell.backend.util;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "app")
+public class AppProperties {
+    private String oauth2SuccessRedirectUrl;
+    private String oauth2FailureRedirectUrl;
+}

--- a/backend/src/main/java/app/signbell/backend/util/CookieProperties.java
+++ b/backend/src/main/java/app/signbell/backend/util/CookieProperties.java
@@ -1,0 +1,21 @@
+package app.signbell.backend.util;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "cookie")
+public class CookieProperties {
+    private String domain;
+    private boolean secure;
+    private boolean httpOnly;
+    private String sameSite; // Lax, Strict, None
+    private String accessTokenName;
+    private String refreshTokenName;
+    private int accessMaxAge; // seconds
+    private int refreshMaxAge; // seconds
+}

--- a/backend/src/main/java/app/signbell/backend/util/CookieUtil.java
+++ b/backend/src/main/java/app/signbell/backend/util/CookieUtil.java
@@ -1,0 +1,113 @@
+package app.signbell.backend.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+/**
+ * HTTP-Only 쿠키 생성/삭제 유틸리티.
+ *
+ * - 보안 플래그(HttpOnly, Secure, SameSite, Domain, Path)를 일관되게 적용합니다.
+ * - SameSite=None일 경우, 브라우저 정책상 Secure=true가 요구됩니다(운영에서 적용).
+ * - 개발 환경에서는 보통 http://localhost 이므로 Secure=false로 설정합니다.
+ *
+ * @author 송민재
+ * @since 2025-10-14
+ */
+@Component
+@RequiredArgsConstructor
+public class CookieUtil {
+
+    private final CookieProperties props;
+
+    /**
+     * Access Token 쿠키를 추가합니다.
+     * @param response 응답 객체
+     * @param token    액세스 토큰 값
+     */
+    public void addAccessTokenCookie(HttpServletResponse response, String token) {
+        ResponseCookie cookie = buildCookie(props.getAccessTokenName(), token, props.getAccessMaxAge());
+        setCookieHeader(response, cookie);
+    }
+
+    /**
+     * Refresh Token 쿠키를 추가합니다.
+     * @param response 응답 객체
+     * @param token    리프레시 토큰 값
+     */
+    public void addRefreshTokenCookie(HttpServletResponse response, String token) {
+        ResponseCookie cookie = buildCookie(props.getRefreshTokenName(), token, props.getRefreshMaxAge());
+        setCookieHeader(response, cookie);
+    }
+
+    public void deleteAccessTokenCookie(HttpServletResponse response) {
+        deleteCookie(response, props.getAccessTokenName());
+    }
+
+    public void deleteRefreshTokenCookie(HttpServletResponse response) {
+        deleteCookie(response, props.getRefreshTokenName());
+    }
+
+    /**
+     * 요청에서 지정한 이름의 쿠키 값을 조회합니다.
+     * @param request 요청
+     * @param name 쿠키 이름
+     * @return 값(없으면 null)
+     */
+    public String readCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+        for (Cookie cookie : cookies) {
+            if (name.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 요청에서 Access Token 쿠키 값을 조회합니다.
+     */
+    public String readAccessToken(HttpServletRequest request) {
+        return readCookie(request, props.getAccessTokenName());
+    }
+
+    /**
+     * 요청에서 Refresh Token 쿠키 값을 조회합니다.
+     */
+    public String readRefreshToken(HttpServletRequest request) {
+        return readCookie(request, props.getRefreshTokenName());
+    }
+
+    /**
+     * 지정한 쿠키를 삭제합니다(max-age=0).
+     */
+    private void deleteCookie(HttpServletResponse response, String name) {
+        ResponseCookie cookie = buildCookie(name, "", 0);
+        setCookieHeader(response, cookie);
+    }
+
+    /**
+     * 공통 쿠키 빌더. 보안 플래그와 도메인, 경로 등을 일관 적용합니다.
+     */
+    private ResponseCookie buildCookie(String name, String value, int maxAgeSeconds) {
+        return ResponseCookie.from(name, value)
+                .httpOnly(props.isHttpOnly())
+                .secure(props.isSecure())
+                .domain(props.getDomain())
+                .path("/")
+                .sameSite(props.getSameSite())
+                .maxAge(maxAgeSeconds)
+                .build();
+    }
+
+    /**
+     * Set-Cookie 헤더에 쿠키를 추가합니다.
+     */
+    private void setCookieHeader(HttpServletResponse response, ResponseCookie cookie) {
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/util/JwtProperties.java
+++ b/backend/src/main/java/app/signbell/backend/util/JwtProperties.java
@@ -1,0 +1,17 @@
+package app.signbell.backend.util;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Setter
+@Configuration
+@ConfigurationProperties(prefix = "jwt")
+// application.yml에서 jwt관련 프로퍼티 값을 읽어오는 클래스
+public class JwtProperties {
+    private String secret; // application.yml: jwt.secret
+    private long accessExpiration;
+    private long refreshExpiration;
+}

--- a/backend/src/main/java/app/signbell/backend/util/JwtTokenProvider.java
+++ b/backend/src/main/java/app/signbell/backend/util/JwtTokenProvider.java
@@ -1,0 +1,117 @@
+package app.signbell.backend.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Date;
+import java.util.Map;
+
+/**
+ * JWT 토큰의 생성과 검증을 담당하는 유틸리티 클래스입니다.
+ *
+ * - 시크릿과 만료시간은 {@link JwtProperties}에서 주입됩니다.
+ * - 시크릿 키는 Base64 문자열을 디코딩해 HMAC-SHA Key로 생성합니다.
+ * - 만료시간 단위는 밀리초(ms)입니다.
+ *
+ * @author 송민재
+ * @since 2025-10-14
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final JwtProperties jwtProperties;
+
+    // 비밀키를 생성
+    private SecretKey key;
+
+    /**
+     * 애플리케이션 시작 시 시크릿 키 초기화.
+     */
+    @PostConstruct
+    public void init() {
+        // Base64로 인코딩된 키를 디코딩해 SecretKey 생성
+        this.key = toSecretKey(jwtProperties.getSecret());
+    }
+
+    /**
+     * Base64 시크릿을 HMAC-SHA 서명 키로 변환.
+     * @param base64Secret Base64로 인코딩된 비밀키 문자열
+     * @return 디코딩된 SecretKey 객체
+     */
+    private SecretKey toSecretKey(String base64Secret) {
+        return Keys.hmacShaKeyFor(Decoders.BASE64.decode(base64Secret));
+    }
+
+    /**
+     * 공통 토큰 생성 헬퍼.
+     * @param subject 토큰 주체(예: 사용자 식별자)
+     * @param claims 커스텀 클레임(Access Token에 최소한으로 포함)
+     * @param expirationMillis 만료시간(ms)
+     */
+    private String createToken(String subject, Map<String, Object> claims, long expirationMillis) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + expirationMillis);
+        return Jwts.builder()
+                .subject(subject)
+                .claims(claims)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * 서명 검증 후 Claims 파싱.
+     * @param token JWT
+     * @return Claims
+     */
+    private Claims parseClaims(String token) {
+        return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+    }
+
+    /**
+     * Access Token 생성.
+     * - 클라이언트 표시/권한 확인용 최소 정보만 클레임에 포함 권장.
+     */
+    public String createAccessToken(String subject, Map<String, Object> claims) {
+        return createToken(subject, claims, jwtProperties.getAccessExpiration());
+    }
+
+    /**
+     * Refresh Token 생성.
+     * - 커스텀 클레임을 넣지 않는 이유:
+     *   1) 최소 권한 원칙: 재발급 용도로만 사용.
+     *   2) 유출 피해 축소: 불필요한 사용자 정보 노출 방지.
+     *   3) 로테이션/블랙리스트 설계와의 궁합상 식별 최소화가 유리.
+     */
+    public String createRefreshToken(String subject) {
+        return createToken(subject, Map.of(), jwtProperties.getRefreshExpiration());
+    }
+
+    /**
+     * 토큰 유효성 검증(서명/만료).
+     * @return 유효하면 true
+     */
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * 토큰에서 Claims 추출(유효하지 않으면 예외).
+     */
+    public Claims getClaims(String token) {
+        return parseClaims(token);
+    }
+}


### PR DESCRIPTION
# Pull Request
> 제목 규칙: **[타입]: 상세 내용 (#이슈번호)** 예: [Feat]: 로그인 기능 구현 (#12)

## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요. (선택된 항목은 자동 라벨링됩니다)
- [x] 기능 (Feature)
- [ ] 버그 수정 (Bugfix)
- [ ] 기능 개선 (Enhancement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
> 이 PR이 무엇을 하는지 한눈에 파악할 수 있도록 핵심 내용을 요약합니다.

OAuth2 소셜 로그인(Kakao)과 JWT를 활용한 인증 로직을 구현했습니다. **액세스/리프레시 토큰 관리** 및 **HTTP-Only 쿠키**를 통한 XSS 최소화에 중점을 두었으며, 서버는 **상태 비저장(Stateless)** 방식으로 운영됩니다.

---

## 관련 이슈 (Related Issue)
> 이 PR과 관련된 이슈 번호를 작성해주세요.  
> (예: Closes #10, Fixes #11, Resolves #12, Relates to #13)

- Closes #15

---

## 변경 사항 (Changes)
> 이 PR로 인해 변경된 점을 상세히 서술합니다.

### 1. 인증 필터 및 토큰 관리
- **`JwtAuthenticationFilter`**: 요청 헤더(`Authorization`) 또는 **HTTP-Only Cookie**에서 JWT를 추출하여 유효성을 검증하고 인증 컨텍스트를 설정하는 로직을 추가했습니다.
- **`JwtTokenProvider`, `CookieUtil`** 등의 유틸리티 클래스를 추가하여 JWT 생성/파싱 및 리프레시 토큰의 안전한 쿠키 저장을 처리합니다.

### 2. OAuth2 연동 및 사용자 관리
- **`User` 엔티티 확장**: 소셜 사용자를 식별하기 위한 **`provider`**, **`providerId`** 필드와 약관 동의 처리를 위한 **`agree`** 필드를 추가했습니다.
- **`CustomOAuth2UserService`**: OAuth2 인증 후 사용자 정보를 조회하고, **`updateProfile`**, **`updateAgreement`** 메서드를 통해 `User` 엔티티에 동기화하는 로직을 구현했습니다.
- **`UserRepository`**: `findByProviderAndProviderId()` 메서드를 수정했습니다.

### 3. 인증 핸들러 및 보안 설정
- **`OAuth2SuccessHandler`**: 로그인 성공 시 액세스/리프레시 토큰을 생성하고, 리프레시 토큰을 HTTP-Only 쿠키에 설정합니다.
- **`SecurityConfig`**: 세션 생성 정책을 **`STATELESS`**로 설정하고, `JwtAuthenticationFilter`를 필터 체인에 연결했습니다.

### 4. 기타
- **`JwtProperties`, `CookieProperties`, `AppProperties`**를 Application 속성 파일로 분리했습니다.

---

## 스크린샷 (Screenshots) (Optional)
> UI/UX 변경 사항이 있다면, 변경 전후 스크린샷을 첨부해주세요.

아래는 로그인 후 포스트맨에서 ACCESS_TOKEN을 헤더에 포함시킨 후 게임방을 만드는 api 테스트 
<img width="851" height="553" alt="{DAB7A363-81A0-4F65-9E64-1BFE6F03F38B}" src="https://github.com/user-attachments/assets/318c13f8-7a86-40ce-8b76-f0a5bd0019a8" />
위는 주소와 보내는 json 내용과 받은 json 내용

<img width="1017" height="90" alt="{0A580EB8-8376-43BD-84FA-FE531F0503DE}" src="https://github.com/user-attachments/assets/67b0409a-279c-4d76-8c83-e69cc2910248" />
헤더에 토큰을 포함 시켜야함.

<img width="1117" height="88" alt="{D26514DE-B791-432A-93FC-9A3F5A1DC8F1}" src="https://github.com/user-attachments/assets/dc2ae238-5e9d-4f52-9ef3-aebad0c6ad80" />
db에 유저 정보 저장 확인

<img width="1640" height="168" alt="{19FE715E-E090-4FFD-BFD2-B3EBA1EE8ED5}" src="https://github.com/user-attachments/assets/049cf37c-9c0f-44f2-997b-ff62645c88ea" />
게임방 db 생성 확인

<img width="1451" height="105" alt="{44402019-1D68-4AF4-B5BE-BFBF466A68E2}" src="https://github.com/user-attachments/assets/f75b45b5-3453-48c7-894c-cafdc43fa06b" />
게임방 참가자  db 생성 확인

---

## 테스트 방법 (Test Steps)
> 리뷰어가 이 변경 사항을 로컬에서 직접 검증할 수 있도록 구체적인 절차를 작성해주세요.

1. Application Properties에 OAuth2 및 JWT 관련 설정을 완료합니다. (소셜 로그인 키 등록)
2. **`bootRun`** 명령으로 애플리케이션을 실행합니다.
3. 브라우저에서 OAuth2 로그인(예: `/oauth2/authorization/kakao`)을 시도하여 성공적으로 리다이렉션 되는지 확인합니다.
     http://localhost:9000/oauth2/authorization/kakao
4. 로그인 성공 후 응답 쿠키에 `refresh_token`이 **HTTP-Only**로 설정되었는지 확인합니다.
5. 액세스 토큰을 사용하여 인가된 API 엔드포인트에 접근이 가능한지 확인합니다.

---

## 셀프 체크리스트 (Self-Checklist)
> 리뷰 요청 전, 아래 항목을 확인해주세요.
- [x] 제목 규칙을 지켰습니다. (제목: [Feat]: OAuth2 및 JWT를 활용한 인증 로직 구현 (#15))
- [x] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [ ] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)
> 리뷰어가 특별히 더 신경 써서 봐야 할 부분이나 참고사항을 작성해주세요.  
> (예: 성능 최적화 부분 집중 검토 필요, API 스펙 변경 사항 확인 요청 등)

1.  **JWT 필터 처리 로직**: `JwtAuthenticationFilter`에서 **헤더와 쿠키** 중 토큰을 찾는 우선순위 및 처리 로직을 중점적으로 검토해 주시면 감사하겠습니다.