### PR TITLE
[Feat]: 마이페이지 사용자 정보 조회 및 수정 백엔드 API 개발 (#24)

### DIFF
--- a/backend/src/main/java/app/signbell/backend/controller/myPage/UserProfileController.java
+++ b/backend/src/main/java/app/signbell/backend/controller/myPage/UserProfileController.java
@@ -1,0 +1,85 @@
+package app.signbell.backend.controller.myPage;
+
+import app.signbell.backend.dto.common.ApiResponse;
+import app.signbell.backend.dto.request.UserProfileUpdateRequest;
+import app.signbell.backend.dto.response.UserProfileResponse;
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
+import app.signbell.backend.service.UserProfileService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 마이페이지 사용자 프로필 조회/수정 컨트롤러.
+ *
+ * 엔드포인트
+ * - GET /api/my-page/users/{userId}/profile: 프로필 조회
+ * - PUT /api/my-page/users/{userId}/profile: 프로필 수정(닉네임, 선택 동의)
+ *
+ * 인증/인가
+ * - `@AuthenticationPrincipal`로 전달되는 subject(문자열)를 Long으로 파싱하여 사용자 ID를 구합니다.
+ * - 서비스는 인가 검증 없이 주어진 userId로만 처리하며, 컨트롤러에서 일치 여부를 검증합니다.
+ *
+ * 응답
+ * - 공통 응답 포맷 `ApiResponse<T>`를 사용합니다.
+ *
+ * 작성자: 송민재
+ * 작성일: 2025-10-15
+ */
+@RestController
+@RequestMapping("/api/my-page/users")
+@RequiredArgsConstructor
+@Slf4j
+public class UserProfileController {
+
+    private final UserProfileService userProfileService;
+
+    /**
+     * 사용자 프로필을 조회합니다.
+     */
+    @GetMapping("/{userId}/profile")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> getProfile(
+            @PathVariable("userId") Long userId,
+            @AuthenticationPrincipal String subject
+    ) {
+        try {
+            Long currentUserId = Long.valueOf(subject);
+            if (!userId.equals(currentUserId)) {
+                throw new BusinessException(ErrorCode.FORBIDDEN);
+            }
+            UserProfileResponse response = userProfileService.getUserProfile(userId);
+            return ResponseEntity.ok(ApiResponse.success("프로필 조회 성공", response));
+        } catch (NumberFormatException e) {
+            log.error("인증된 사용자 ID(subject)를 Long으로 변환 실패: {}", subject, e);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+
+    /**
+     * 사용자 프로필을 수정합니다.
+     */
+    @PatchMapping("/{userId}/profile")
+    public ResponseEntity<ApiResponse<UserProfileResponse>> updateProfile(
+            @PathVariable("userId") Long userId,
+            @Valid @RequestBody UserProfileUpdateRequest request,
+            @AuthenticationPrincipal String subject
+    ) {
+        try {
+            Long currentUserId = Long.valueOf(subject);
+            if (!userId.equals(currentUserId)) {
+                throw new BusinessException(ErrorCode.FORBIDDEN);
+            }
+            UserProfileResponse response = userProfileService.updateUserProfile(userId, request);
+            return ResponseEntity.ok(ApiResponse.success("프로필 수정 성공", response));
+        } catch (NumberFormatException e) {
+            log.error("인증된 사용자 ID(subject)를 Long으로 변환 실패: {}", subject, e);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+}
+
+

--- a/backend/src/main/java/app/signbell/backend/dto/request/UserProfileUpdateRequest.java
+++ b/backend/src/main/java/app/signbell/backend/dto/request/UserProfileUpdateRequest.java
@@ -1,0 +1,30 @@
+package app.signbell.backend.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserProfileUpdateRequest {
+
+    /**
+     * 닉네임 (필수, 1~20자)
+     */
+    @NotBlank(message = "닉네임은 필수 입력 항목입니다.")
+    @Size(min = 1, max = 20, message = "닉네임은 1자에서 20자 사이여야 합니다.")
+    private String nickname;
+
+    /**
+     * 약관 동의 여부 (선택)
+     */
+    private Boolean optionalAgree;
+
+    @Builder
+    public UserProfileUpdateRequest(String nickname, Boolean optionalAgree) {
+        this.nickname = nickname;
+        this.optionalAgree = optionalAgree;
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/dto/response/UserProfileResponse.java
+++ b/backend/src/main/java/app/signbell/backend/dto/response/UserProfileResponse.java
@@ -1,0 +1,29 @@
+package app.signbell.backend.dto.response;
+
+import app.signbell.backend.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 마이페이지에 유저 프로필 정보를 제공하는 DTO
+ *
+ * @author 송민재
+ * @since 2025-10-15
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserProfileResponse {
+    private String nickname;
+    private String profileImageUrl;
+    private Boolean optionalAgree;
+
+    public static UserProfileResponse from(User user) {
+        return UserProfileResponse.builder()
+                .nickname(user.getNickname())
+                .profileImageUrl(user.getProfileImageUrl())
+                .optionalAgree(user.getOptionalAgree())
+                .build();
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/entity/User.java
+++ b/backend/src/main/java/app/signbell/backend/entity/User.java
@@ -71,10 +71,16 @@ public class User {
     private String providerId;
 
     /**
-     * 약관 동의 여부 (누락 필드 추가)
+     * 필수 약관 동의 여부 (누락 필드 추가)
      */
     @Column(nullable = false)
-    private Boolean agree;
+    private Boolean requiredAgree;
+
+    /**
+     * 선택 약관 동의 여부 (누락 필드 추가)
+     */
+    @Column(nullable = false)
+    private Boolean optionalAgree;
 
 
     /**
@@ -119,7 +125,8 @@ public class User {
      * @param profileImageUrl 사용자의 프로필 이미지 URL
      * @param provider 사용자가 가입한 OAuth 제공자 (예: Google, Facebook 등)
      * @param providerId OAuth 제공자에서 부여한 사용자 ID
-     * @param agree 약관 동의 여부 (기본값: false)
+     * @param requiredAgree 필수 약관 동의 여부 (기본값: false)
+     * @param optionalAgree 선택 약관 동의 여부 (기본값: false)
      *
      * @author 송민재
      * @since 2025-10-14
@@ -131,7 +138,9 @@ public class User {
             , LoginMethod provider
             , String providerId
             , String email
-            , Boolean agree
+//            , Boolean agree
+            , Boolean requiredAgree
+            , Boolean optionalAgree
     ) {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
@@ -140,7 +149,9 @@ public class User {
         this.email = email;
 
         // 값이 null일 경우 기본값으로 대체
-        this.agree = agree != null ? agree : false;
+//        this.agree = agree != null ? agree : false;
+        this.requiredAgree = requiredAgree != null ? requiredAgree : false;
+        this.optionalAgree = optionalAgree != null ? optionalAgree : false;
         this.totalScore = 0L; // 빌더에서 totalScore 초기화
     }
 
@@ -171,11 +182,24 @@ public class User {
     }
 
     /**
-     * 사용자의 동의 상태 업데이트 편의 메서드
+     * 사용자의 필수 동의 상태 업데이트 편의 메서드
      * @author 송민재
      * @since 2025-10-14
      */
-    public void updateAgreement() {
-        this.agree = true;
+    public void updateRequiredAgreement() {
+        this.requiredAgree = true;
     }
+
+    /**
+     * 사용자 프로필을 요청 DTO 기반으로 업데이트합니다.
+     * - 닉네임: 요청 DTO가 @NotBlank로 보장하므로 그대로 적용
+     * - 선택 동의: null이면 기존 값 유지
+     */
+    public void updateProfile(app.signbell.backend.dto.request.UserProfileUpdateRequest request) {
+        this.nickname = request.getNickname();
+        if (request.getOptionalAgree() != null) {
+            this.optionalAgree = request.getOptionalAgree();
+        }
+    }
+
 }

--- a/backend/src/main/java/app/signbell/backend/service/UserProfileService.java
+++ b/backend/src/main/java/app/signbell/backend/service/UserProfileService.java
@@ -1,0 +1,84 @@
+package app.signbell.backend.service;
+
+import app.signbell.backend.dto.request.UserProfileUpdateRequest;
+import app.signbell.backend.dto.response.UserProfileResponse;
+import app.signbell.backend.entity.User;
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
+import app.signbell.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 사용자 프로필 조회/수정을 담당하는 서비스.
+ *
+ * 동작 개요
+ * 1) getUserProfile: 사용자 ID로 조회하여 프로필 응답 DTO로 변환
+ * 2) updateUserProfile: 닉네임/선택 약관 동의(optionalAgree) 변경 후 변경 감지로 반영
+ *
+ * 예외 처리
+ * - 존재하지 않는 사용자: BusinessException(ErrorCode.USER_NOT_FOUND)
+ *
+ * 트랜잭션 정책
+ * - 조회 메서드는 readOnly 트랜잭션
+ * - 수정 메서드는 기본 트랜잭션으로 변경 감지(dirty checking) 반영
+ *
+ * @author 송민재
+ * @since 2025-10-15
+ */
+@Service
+@RequiredArgsConstructor
+public class UserProfileService {
+
+    private final UserRepository userRepository;
+
+    /**
+     * 사용자 프로필을 조회합니다.
+     *
+     * 절차
+     * - userId로 사용자를 조회
+     * - 없으면 USER_NOT_FOUND 예외 발생
+     * - User를 UserProfileResponse로 변환하여 반환
+     *
+     * @param userId 사용자 ID
+     * @return 사용자 프로필 응답 DTO
+     *
+     * @author 송민재
+     * @since 2025-10-15
+     */
+    @Transactional(readOnly = true)
+    public UserProfileResponse getUserProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        return UserProfileResponse.from(user);
+    }
+
+    /**
+     * 사용자 프로필을 수정합니다.
+     *
+     * 절차
+     * - userId로 사용자를 조회 (없으면 USER_NOT_FOUND)
+     * - 닉네임과 선택 약관 동의 상태(optionalAgree)를 업데이트
+     * - JPA 변경 감지를 통해 저장소에 반영
+     * - 변경된 상태를 UserProfileResponse로 변환하여 반환
+     *
+     * @param userId 사용자 ID
+     * @param request 닉네임/선택 동의 수정 요청
+     * @return 수정된 사용자 프로필 응답 DTO
+     *
+     * @author 송민재
+     * @since 2025-10-15
+     */
+    @Transactional
+    public UserProfileResponse updateUserProfile(Long userId, UserProfileUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 단일 업데이트 메서드로 응집도 있게 수정
+        user.updateProfile(request);
+
+        // JPA 변경감지로 flush, 명시적 save는 선택 사항
+        return UserProfileResponse.from(user);
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/util/SecurityUtils.java
+++ b/backend/src/main/java/app/signbell/backend/util/SecurityUtils.java
@@ -1,0 +1,33 @@
+package app.signbell.backend.util;
+
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+/**
+ * 보안 관련 공통 유틸리티.
+ *
+ * - 현재 인증된 사용자 ID 조회 (JwtAuthenticationFilter가 subject를 userId로 세팅)
+ *
+ * 작성자: 송민재
+ * 작성일: 2025-10-15
+ */
+public final class SecurityUtils {
+
+    private SecurityUtils() {}
+
+    public static Long getCurrentUserIdOrThrow() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || authentication.getName() == null) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        try {
+            return Long.valueOf(authentication.getName());
+        } catch (NumberFormatException e) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+}
+
+


### PR DESCRIPTION
# Pull Request
> 제목 규칙: **[타입]: 상세 내용 (#이슈번호)** 예: [Feat]: 로그인 기능 구현 (#12)

**[Feat]: 마이페이지 사용자 프로필 조회 및 수정 API 구현 (#24)**

## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요. (선택된 항목은 자동 라벨링됩니다)
- [x] 기능 (Feature)
- [ ] 버그 수정 (Bugfix)
- [ ] 기능 개선 (Enhancement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
> 이 PR이 무엇을 하는지 한눈에 파악할 수 있도록 핵심 내용을 요약합니다.

유저 ID 기반으로 사용자 프로필 정보(닉네임, 이미지 URL, 선택 약관 동의 여부)를 조회하고, 닉네임 또는 선택 약관 동의 여부를 수정하는 백엔드 API 기능을 구현합니다.

* **주요 기능:** 사용자 프로필 조회 (`GET`) 및 수정 (`PATCH`) API 추가.
* **엔티티 변경:** 약관 동의 필드를 **필수/선택**으로 분리하여 `User` 엔티티를 확장했습니다.
* **보안 강화:** 인증된 사용자 ID를 활용하여 본인에 대한 요청만 처리하도록 권한 검증 로직을 추가했습니다.

---

## 관련 이슈 (Related Issue)
> 이 PR과 관련된 이슈 번호를 작성해주세요.
> (예: Closes #10, Fixes #11, Resolves #12, Relates to #13)

- Closes #24 (마이페이지 사용자 정보 조회 및 수정 백엔드 API 개발)

---

## 변경 사항 (Changes)
> 이 PR로 인해 변경된 점을 상세히 서술합니다.

### 1. 엔티티 및 도메인 로직 변경 (Commit: 약관 동의 관련 필드 추가 및 로직 수정)
* `User` 엔티티에 `requiredAgree` (필수), `optionalAgree` (선택) 약관 동의 필드 (`boolean`)를 추가하고, 기존 `agree` 필드를 삭제했습니다.
* 선택 약관 동의 상태를 업데이트하는 `updateProfile` 메서드를 `User` 엔티티에 추가했습니다.

### 2. DTO 구조 정의 (Commit: 유저 프로필 DTO 추가)
* **요청 DTO:** `UserProfileUpdateRequest` (닉네임, 선택 약관 동의 여부)를 추가하고 유효성 검사 어노테이션을 적용했습니다.
* **응답 DTO:** `UserProfileResponse` (닉네임, 프로필 이미지 URL, 선택 약관 동의 여부)를 추가했습니다.

### 3. 유틸리티 및 서비스 로직 추가 (Commit: 인증된 사용자 ID 조회 유틸리티 추가 & 사용자 프로필 서비스 추가)
* `SecurityUtils`: 현재 인증된 사용자 ID를 안전하게 조회하는 유틸리티 클래스를 추가했습니다.
* `UserProfileService`:
    * `getUserProfile`: 사용자 ID로 프로필 정보를 조회하여 `UserProfileResponse`로 반환하는 로직을 구현했습니다.
    * `updateUserProfile`: 닉네임 중복 검사 및 엔티티 변경 감지를 통해 사용자 프로필을 업데이트하는 로직을 구현했습니다. (읽기 전용 트랜잭션 분리)

### 4. 컨트롤러 및 API 엔드포인트 추가 (Commit: 사용자 프로필 조회/수정 컨트롤러 추가)
* `MyPageController`를 추가하고 다음 RESTful API 엔드포인트를 구현했습니다.
    * `GET /api/my-page/users/{userId}/profile`: 사용자 프로필 조회
    * `PATCH /api/my-page/users/{userId}/profile`: 사용자 프로필 수정
* **권한 검증:** 요청된 `{userId}`와 `@AuthenticationPrincipal`의 ID가 일치하는지 확인하는 권한 검증 로직을 추가했습니다.

---

## 스크린샷 (Screenshots) (Optional)
> UI/UX 변경 사항이 있다면, 변경 전후 스크린샷을 첨부해주세요.

(여기에 파일 첨부)

---

## 테스트 방법 (Test Steps)
> 리뷰어가 이 변경 사항을 로컬에서 직접 검증할 수 있도록 구체적인 절차를 작성해주세요.

## 참고(테스트 단계라서 매번 db가 초기화 되기에 새로 로그인하면 자신의 userId는 1일 것을 가정하고 진행함(/api/my-page/users/{userId}/profile). user테이블에서 확인 가능함)
> 1. 아래 주소 클릭 후 카카오톡 로그인
     http://localhost:9000/oauth2/authorization/kakao
     
> 2. f12눌러서 개발자 모드 열기 -> Application의 Cookie에서 ACCESS_TOKEN 복사
<img width="891" height="640" alt="{83977C13-470C-4E75-98B6-31A0BFE3E77F}" src="https://github.com/user-attachments/assets/3273f4c0-786a-4687-ac50-65b3a3c35ffb" />

---

> 3. Postman 데스크탑 앱 열고 Add request 누르기(+버튼)
<img width="295" height="107" alt="{52BC91C6-1D5A-4F36-A14A-C49BDACB4673}" src="https://github.com/user-attachments/assets/064f414a-16a9-4fd7-b439-d3e00b17047c" />

---

> 4. 마이페이지 조회 기능 테스트하기
<img width="890" height="624" alt="{E51A749E-EABF-4D93-B425-436B0FFDD1BF}" src="https://github.com/user-attachments/assets/b37d3dd4-7628-4bf4-a5d7-d100a0cfdb21" />
[성공]로그인 후 자신의 마이페이지 조회

---

HTTP 메소드:   GET
주소:    http://localhost:9000/api/my-page/users/1/profile
방법:
     1. Authorization의 Auth Type을 Bearer Token으로 하고 옆의 토큰의 2번에서 복사한 ACCESS_TOKEN 붙여넣기
     2. Body는 none으로 설정함
     3. 오른쪽 상단 Send누르기
응답json:

```json
{
    "success": true,
    "message": "프로필 조회 성공",
    "timestamp": "2025-10-15T17:12:20.1934335",
    "data": {
        "nickname": "송민재",
        "profileImageUrl": "http://k.kakaocdn.net/dn/jnklU/btsPFZKQSrJ/aHNecgxEqPLdnpIVw9ZR0K/img_640x640.jpg",
        "optionalAgree": false
    }
}
```

<img width="674" height="591" alt="{0E4F8057-558A-406B-A450-252CB64374D8}" src="https://github.com/user-attachments/assets/b6ec14f8-28fe-40ea-90d6-f2de2ccf954e" />

[실패]로그인 없이 마이페이지 조회(또는 다른사람의 마이페이지 접속 시도)

---

> 5. 마이페이지 수정 기능 테스트하기
<img width="907" height="644" alt="{F1CBF06E-B6A9-4912-B3B1-C6897B68B08A}" src="https://github.com/user-attachments/assets/365f052a-e7c6-4486-b601-a61ee85d3cb6" />
[성공]로그인 후 자신의 마이페이지 수정

HTTP 메소드:   PATCH
주소:    http://localhost:9000/api/my-page/users/1/profile
방법:
     1. Authorization의 Auth Type을 Bearer Token으로 하고 옆의 토큰의 2번에서 복사한 ACCESS_TOKEN 붙여넣기
     2. Body는 아래 raw 선택 후 json 넣기

```json
{
    "nickname":"변경된이름",
    "optionalAgree":true
}
```

     3. 오른쪽 상단 Send누르기
     
응답json:

```json
{
    "success": true,
    "message": "프로필 수정 성공",
    "timestamp": "2025-10-15T17:12:20.1934335",
    "data": {
        "nickname": "변경된이름",
        "profileImageUrl": "http://k.kakaocdn.net/dn/jnklU/btsPFZKQSrJ/aHNecgxEqPLdnpIVw9ZR0K/img_640x640.jpg",
        "optionalAgree": true
    }
}
```     
 
<img width="953" height="604" alt="{69429FDC-C436-46CA-B863-3B3FA957441F}" src="https://github.com/user-attachments/assets/c874e928-ecf8-4900-b425-08681db45f0e" />
[실패]로그인 없이 마이페이지 수정

---

<img width="891" height="640" alt="{83977C13-470C-4E75-98B6-31A0BFE3E77F}" src="https://github.com/user-attachments/assets/71a3b887-2820-43e3-8f86-0e2049b0e5de" />
[성공]로그인 후 수정 후 자신의 마이페이지 조회


---

## 셀프 체크리스트 (Self-Checklist)
> 리뷰 요청 전, 아래 항목을 확인해주세요.
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [ ] CI/CD 파이프라인이 통과했습니다. (PR 생성 후 확인 예정)

---

## 리뷰어에게 (To Reviewers)
> 리뷰어가 특별히 더 신경 써서 봐야 할 부분이나 참고사항을 작성해주세요.
> (예: 성능 최적화 부분 집중 검토 필요, API 스펙 변경 사항 확인 요청 등)

* **권한 검증 로직:** `MyPageController`에서 `SecurityUtils`를 사용하여 현재 인증된 사용자와 요청 `userId`를 비교하는 로직의 안정성을 집중적으로 검토 부탁드립니다.
* **엔티티 변경:** `User` 엔티티에서 필수/선택 약관을 분리하는 방식(`requiredAgree`, `optionalAgree`)이 기존 로직에 미치는 영향 및 일관성을 확인 부탁드립니다.
* **트랜잭션 관리:** `UserProfileService`에서 조회/수정 메서드에 적용된 트랜잭션 정책 (`readOnly = true` 등)이 올바른지 확인 부탁드립니다.

---
