### PR TITLE
[Feat]: STOMP 기반 게임 방 입장 처리 및 브로드캐스트 추가 (#23)

### DIFF
--- a/backend/src/main/java/app/signbell/backend/controller/gameRoom/GameRoomJoinController.java
+++ b/backend/src/main/java/app/signbell/backend/controller/gameRoom/GameRoomJoinController.java
@@ -1,0 +1,150 @@
+package app.signbell.backend.controller.gameRoom;
+
+import app.signbell.backend.dto.common.ApiResponse;
+import app.signbell.backend.dto.request.JoinRoomRequest;
+import app.signbell.backend.dto.response.JoinRoomResponse;
+import app.signbell.backend.dto.response.ParticipantEventResponse;
+import app.signbell.backend.dto.response.ParticipantResponse;
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
+import app.signbell.backend.exception.dto.ErrorResponse;
+import app.signbell.backend.service.GameRoomJoinService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+import java.time.LocalDateTime;
+
+/**
+ * GameRoomJoinController 클래스는 WebSocket을 통한 게임 방 입장 요청을 처리하는 컨트롤러입니다.
+ *
+ * 주요 역할:
+ * 1. 클라이언트로부터 방 입장 요청을 수신합니다.
+ * 2. JWT 기반 사용자 인증을 통해 요청자를 식별합니다.
+ * 3. GameRoomJoinService를 호출하여 비즈니스 로직을 처리합니다.
+ * 4. 입장한 사용자 개인에게 방 전체 정보를 전송합니다.
+ * 5. 방에 있는 모든 참가자에게 새 참가자 입장 알림을 브로드캐스트합니다.
+ * 6. 에러 발생 시 해당 사용자에게만 에러 메시지를 전송합니다.
+ *
+ * STOMP 프로토콜을 사용하며, 다음과 같은 메시지 경로를 처리합니다:
+ * - 수신: /app/room/{gameRoomId}/join
+ * - 개인 응답: /user/queue/room
+ * - 브로드캐스트: /topic/room/{gameRoomId}/participant
+ * - 에러 응답: /user/queue/errors
+ *
+ * @author 강관주
+ * @since 2025-10-15
+ */
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class GameRoomJoinController {
+
+    private final GameRoomJoinService gameRoomJoinService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * 게임 방 입장 요청을 처리하는 메서드.
+     *
+     * 클라이언트가 /app/room/{gameRoomId}/join 경로로 메시지를 전송하면
+     * 이 메서드가 호출되어 방 입장 로직을 처리합니다.
+     *
+     * 처리 흐름:
+     * 1. JWT 토큰에서 사용자 ID를 추출합니다.
+     * 2. GameRoomJoinService를 호출하여 방 입장을 처리합니다.
+     * 3. 입장 성공 시 입장자 개인에게 방 전체 정보를 전송합니다.
+     * 4. 방에 있는 모든 참가자에게 새 참가자 입장 알림을 브로드캐스트합니다.
+     * 5. 에러 발생 시 해당 사용자에게만 에러 메시지를 전송합니다.
+     *
+     * @param gameRoomId 입장하려는 게임 방의 ID (URL 경로에서 추출)
+     * @param request 방 입장 요청 데이터 (메시지 본문)
+     * @param subject JWT 토큰에서 추출한 사용자 ID (Principal)
+     */
+    @MessageMapping("/room/{gameRoomId}/join")
+    public void joinRoom(
+            @DestinationVariable Long gameRoomId,
+            @Payload JoinRoomRequest request,
+            @AuthenticationPrincipal String subject
+    ) {
+        try {
+            Long userId = Long.valueOf(subject);
+            log.info("Join room request - userId: {}, gameRoomId: {}", userId, gameRoomId);
+
+            // 1. 방 입장 처리
+            JoinRoomResponse response = gameRoomJoinService.joinRoom(userId, gameRoomId);
+
+            // 2. 입장자 개인에게 응답 (방 전체 정보)
+            messagingTemplate.convertAndSendToUser(
+                    subject,
+                    "/queue/room",
+                    ApiResponse.success("방에 입장했습니다.", response)
+            );
+
+            // 3. 방 전체에 브로드캐스트 (새 참가자 알림)
+            // 새로 입장한 참가자 정보 추출
+            ParticipantResponse newParticipant = response.getParticipants()
+                    .get(response.getParticipants().size() - 1);
+
+            // 이벤트 객체 생성
+            ParticipantEventResponse event = ParticipantEventResponse.builder()
+                    .eventType("PARTICIPANT_JOINED")
+                    .participant(newParticipant)
+                    .currentParticipants(response.getCurrentParticipants())
+                    .build();
+
+            // 브로드캐스트 (방 전체에 알림)
+            messagingTemplate.convertAndSend(
+                    "/topic/room/" + gameRoomId + "/participant",
+                    ApiResponse.success("새로운 참가자가 입장했습니다.", event)
+            );
+
+            log.info("Join room success - userId: {}, gameRoomId: {}", userId, gameRoomId);
+
+        } catch (BusinessException e) {
+            log.warn("Business exception during join room - errorCode: {}, message: {}",
+                    e.getErrorCode().getCode(), e.getMessage());
+            sendError(subject, e.getErrorCode());
+
+        } catch (NumberFormatException e) {
+            log.error("Invalid user ID format - subject: {}", subject);
+            sendError(subject, ErrorCode.INVALID_INPUT);
+
+        } catch (Exception e) {
+            log.error("Unexpected error during join room", e);
+            sendError(subject, ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * 에러 메시지를 특정 사용자에게 전송하는 메서드.
+     *
+     * 방 입장 처리 중 발생한 에러를 해당 사용자에게만 전송합니다.
+     * ErrorCode를 기반으로 ErrorResponse 객체를 생성하여 전송합니다.
+     *
+     * @param userId 에러 메시지를 받을 사용자의 ID
+     * @param errorCode 발생한 에러의 ErrorCode
+     */
+    private void sendError(String userId, ErrorCode errorCode) {
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(errorCode.getStatus())
+                .error(errorCode.getCode())
+                .detail(errorCode.getMessage())
+                .path("/app/room/join")
+                .build();
+
+        messagingTemplate.convertAndSendToUser(
+                userId,
+                "/queue/errors",
+                error
+        );
+
+        log.warn("Error sent to user {} - code: {}, message: {}",
+                userId, errorCode.getCode(), errorCode.getMessage());
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/dto/request/JoinRoomRequest.java
+++ b/backend/src/main/java/app/signbell/backend/dto/request/JoinRoomRequest.java
@@ -1,0 +1,19 @@
+package app.signbell.backend.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 방 참가 요청 정보를 담는 클래스.
+ *
+ * 이 클래스는 특정 게임 방에 참가하기 위한 요청 데이터를 정의합니다.
+ * `gameRoomId` 필드를 통해 사용자가 참가하고자 하는 게임 방의 고유 식별자를 설정합니다.
+ *
+ * @author 강관주
+ * @since 2025-10-15
+ */
+@Getter
+@NoArgsConstructor
+public class JoinRoomRequest {
+    private Long gameRoomId;
+}

--- a/backend/src/main/java/app/signbell/backend/dto/response/JoinRoomResponse.java
+++ b/backend/src/main/java/app/signbell/backend/dto/response/JoinRoomResponse.java
@@ -1,0 +1,46 @@
+package app.signbell.backend.dto.response;
+
+import app.signbell.backend.entity.GameRoom;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 게임방 참여 후 반환되는 응답 데이터를 담는 클래스.
+ *
+ * 이 클래스는 특정 게임방에 참가한 이후 해당 방의 정보를 포함한 응답 데이터로 사용된다.
+ * 내부적으로 게임방의 ID, 제목, 방장, 참가자 정보, 현재 참가자 수, 최대 참가자 수, 현재 라운드, 상태값 등을 포함한다.
+ *
+ * 주요 용도:
+ * - 게임방 참여 요청에 대한 응답 데이터 전달
+ * - 클라이언트가 게임방의 상태를 확인할 수 있도록 정보를 제공
+ *
+ * @author 강관주
+ * @since 2025-10-15
+ */
+@Getter
+@Builder
+public class JoinRoomResponse {
+    private Long gameRoomId;
+    private String gameTitle;
+    private Long hostId;
+    private List<ParticipantResponse> participants;
+    private Integer currentParticipants;
+    private Integer maxParticipants;
+    private Integer currentRound;
+    private String status;
+
+    public static JoinRoomResponse of(GameRoom room, List<ParticipantResponse> participants) {
+        return JoinRoomResponse.builder()
+                .gameRoomId(room.getId())
+                .gameTitle(room.getGameTitle())
+                .hostId(room.getHost().getId())
+                .participants(participants)
+                .currentParticipants(room.getCurrentParticipants())
+                .maxParticipants(room.getMaxParticipants())
+                .currentRound(room.getCurrentRound())
+                .status(room.getStatus().name())
+                .build();
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/dto/response/ParticipantEventResponse.java
+++ b/backend/src/main/java/app/signbell/backend/dto/response/ParticipantEventResponse.java
@@ -1,0 +1,27 @@
+package app.signbell.backend.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * ParticipantEventResponse 클래스는 특정 이벤트와 관련된 참가자의 상태 정보를 나타내는 응답 객체입니다.
+ *
+ * 주요 사용 사례:
+ * - 사용자 이벤트 발생 시 해당 이벤트와 관련된 정보를 응답 형태로 전달
+ * - 이벤트 유형(eventType), 이벤트에 연관된 참가자 정보(participant), 현재 참가자 수(currentParticipants)를 포함
+ *
+ * 주요 필드:
+ * - eventType: 이벤트 유형을 나타내는 문자열, 예를 들어 "PARTICIPANT_JOINED"와 같은 값
+ * - participant: 이벤트와 연관된 개별 참가자에 대한 정보를 담은 ParticipantResponse 객체
+ * - currentParticipants: 이벤트 발생 시점의 현재 게임방 참가자 수
+ *
+ * @author 강관주
+ * @since 2025-10-15
+ */
+@Getter
+@Builder
+public class ParticipantEventResponse {
+    private String eventType;  // "PARTICIPANT_JOINED"
+    private ParticipantResponse participant;
+    private Integer currentParticipants;
+}

--- a/backend/src/main/java/app/signbell/backend/dto/response/ParticipantResponse.java
+++ b/backend/src/main/java/app/signbell/backend/dto/response/ParticipantResponse.java
@@ -1,0 +1,41 @@
+package app.signbell.backend.dto.response;
+
+import app.signbell.backend.entity.GameParticipant;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * ParticipantResponse 클래스는 게임 참가자의 데이터를 응답 형식으로 전달하기 위한 DTO입니다.
+ *
+ * 이 클래스는 게임 참가자의 ID, 닉네임, 프로필 이미지 URL, 방장 여부, 레디 상태 정보를 포함합니다.
+ * 엔티티와의 의존성을 최소화하고 클라이언트가 이해하기 쉬운 데이터 구조로 변환하는 역할을 합니다.
+ *
+ * 주요 역할:
+ * - GameParticipant 엔티티로부터 사용자 데이터를 변환하여 클라이언트에 전달
+ * - 게임 대기실 또는 게임방 관련 API 응답 데이터로 사용
+ *
+ * 주요 메서드:
+ * - from(GameParticipant participant): GameParticipant 엔티티를 기반으로 ParticipantResponse 객체를 생성합니다.
+ *
+ * @author 강관주
+ * @since 2025-10-15
+ */
+@Getter
+@Builder
+public class ParticipantResponse {
+    private Long userId;
+    private String nickname;
+    private String profileImageUrl;
+    private boolean isHost;
+    private boolean isReady;
+
+    public static ParticipantResponse from(GameParticipant participant) {
+        return ParticipantResponse.builder()
+                .userId(participant.getParticipant().getId())
+                .nickname(participant.getParticipant().getNickname())
+                .profileImageUrl(participant.getParticipant().getProfileImageUrl())
+                .isHost(participant.isHost())
+                .isReady(participant.isReady())
+                .build();
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/entity/GameRoom.java
+++ b/backend/src/main/java/app/signbell/backend/entity/GameRoom.java
@@ -79,6 +79,13 @@ public class GameRoom {
     @UpdateTimestamp
     private LocalDateTime updatedAt;
 
+    /**
+     * GameRoom 생성자를 통해 게임방을 초기화합니다.
+     *
+     * @param gameTitle 게임방 제목
+     * @param host 게임방 방장
+     * @param status 게임방 상태값 (대기중/진행중/종료)
+     */
     @Builder
     public GameRoom(String gameTitle, User host, GameRoomStatus status) {
         this.gameTitle = gameTitle;
@@ -96,5 +103,21 @@ public class GameRoom {
      */
     public void proceedToNextRound() {
         this.currentRound++;
+    }
+
+    /**
+     * 참가자 수를 1 증가시킵니다.
+     */
+    public void incrementParticipants() {
+        this.currentParticipants++;
+    }
+
+    /**
+     * 참가자 수를 1 감소시킵니다.
+     */
+    public void decrementParticipants() {
+        if (this.currentParticipants > 0) {
+            this.currentParticipants--;
+        }
     }
 }

--- a/backend/src/main/java/app/signbell/backend/repository/GameParticipantRepository.java
+++ b/backend/src/main/java/app/signbell/backend/repository/GameParticipantRepository.java
@@ -5,6 +5,9 @@ import app.signbell.backend.entity.GameRoomStatus;
 import app.signbell.backend.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 /**
  * GameParticipantRepository 인터페이스는 게임 대기실 참여자 정보(GameParticipant 엔티티)에 대한
  * 데이터베이스 CRUD 작업을 처리하기 위해 Spring Data JPA에서 제공하는
@@ -29,4 +32,25 @@ public interface GameParticipantRepository extends JpaRepository<GameParticipant
      * @return 참여 중이면 true
      */
     boolean existsByParticipantAndGameRoom_StatusIn(User participant, GameRoomStatus... statuses);
+
+    /**
+     * 특정 게임방의 모든 참가자 조회
+     * @param gameRoomId 게임방 ID
+     * @return 해당 게임방의 참가자 리스트
+     */
+    List<GameParticipant> findByGameRoom_Id(Long gameRoomId);
+
+    /**
+     * 특정 사용자의 참가 정보 조회
+     * @param userId 사용자 ID
+     * @return 사용자의 참가 정보 (Optional)
+     */
+    Optional<GameParticipant> findByParticipant_Id(Long userId);
+
+    /**
+     * 특정 게임방의 참가자 수 조회
+     * @param gameRoomId 게임방 ID
+     * @return 해당 게임방의 참가자 수
+     */
+    long countByGameRoom_Id(Long gameRoomId);
 }

--- a/backend/src/main/java/app/signbell/backend/repository/GameParticipantRepository.java
+++ b/backend/src/main/java/app/signbell/backend/repository/GameParticipantRepository.java
@@ -4,6 +4,8 @@ import app.signbell.backend.entity.GameParticipant;
 import app.signbell.backend.entity.GameRoomStatus;
 import app.signbell.backend.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,18 +36,29 @@ public interface GameParticipantRepository extends JpaRepository<GameParticipant
     boolean existsByParticipantAndGameRoom_StatusIn(User participant, GameRoomStatus... statuses);
 
     /**
-     * 특정 게임방의 모든 참가자 조회
+     * 특정 게임방의 모든 참가자 조회 (User 정보 함께 fetch)
+     * N+1 문제 방지를 위해 participant를 즉시 로딩합니다.
+     *
      * @param gameRoomId 게임방 ID
-     * @return 해당 게임방의 참가자 리스트
+     * @return 해당 게임방의 참가자 리스트 (User 정보 포함)
      */
-    List<GameParticipant> findByGameRoom_Id(Long gameRoomId);
+    @Query("SELECT gp FROM GameParticipant gp " +
+            "JOIN FETCH gp.participant " +
+            "WHERE gp.gameRoom.id = :gameRoomId")
+    List<GameParticipant> findByGameRoom_Id(@Param("gameRoomId") Long gameRoomId);
 
     /**
-     * 특정 사용자의 참가 정보 조회
+     * 특정 사용자의 참가 정보 조회 (GameRoom과 User 정보 함께 fetch)
+     * N+1 문제 방지를 위해 연관된 엔티티를 즉시 로딩합니다.
+     *
      * @param userId 사용자 ID
-     * @return 사용자의 참가 정보 (Optional)
+     * @return 사용자의 참가 정보 (Optional, GameRoom 및 User 정보 포함)
      */
-    Optional<GameParticipant> findByParticipant_Id(Long userId);
+    @Query("SELECT gp FROM GameParticipant gp " +
+            "JOIN FETCH gp.participant " +
+            "JOIN FETCH gp.gameRoom " +
+            "WHERE gp.participant.id = :userId")
+    Optional<GameParticipant> findByParticipant_Id(@Param("userId") Long userId);
 
     /**
      * 특정 게임방의 참가자 수 조회

--- a/backend/src/main/java/app/signbell/backend/service/GameRoomJoinService.java
+++ b/backend/src/main/java/app/signbell/backend/service/GameRoomJoinService.java
@@ -1,0 +1,125 @@
+package app.signbell.backend.service;
+
+import app.signbell.backend.dto.response.JoinRoomResponse;
+import app.signbell.backend.dto.response.ParticipantResponse;
+import app.signbell.backend.entity.GameParticipant;
+import app.signbell.backend.entity.GameRoom;
+import app.signbell.backend.entity.GameRoomStatus;
+import app.signbell.backend.entity.User;
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
+import app.signbell.backend.repository.GameParticipantRepository;
+import app.signbell.backend.repository.GameRoomRepository;
+import app.signbell.backend.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * GameRoomService 클래스는 게임 방 입장을 처리하는 서비스 클래스입니다.
+ *
+ * 주요 역할:
+ * 1. 게임 방의 존재 여부와 상태를 검증합니다.
+ * 2. 방 인원 수를 확인하여 입장 가능 여부를 판단합니다.
+ * 3. 사용자가 중복으로 방에 참여 중인지 확인합니다.
+ * 4. 참가자를 게임 방에 추가하고 DB에 저장합니다.
+ * 5. 방의 현재 참가자 목록과 함께 입장 결과를 반환합니다.
+ *
+ * 사용자가 게임 방에 입장하려는 WebSocket 요청을 처리하며,
+ * 필요한 경우 예외를 발생시켜 무결성을 보장합니다.
+ *
+ * @author 강관주
+ * @since 2025-10-15
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class GameRoomJoinService {
+
+    private final GameRoomRepository gameRoomRepository;
+    private final GameParticipantRepository participantRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 사용자를 게임 방에 입장시키는 메서드.
+     *
+     * 주어진 사용자 ID와 게임 방 ID를 기반으로 방 입장을 처리합니다.
+     * 방의 존재 여부, 상태, 인원 수, 중복 입장 여부를 검증한 후,
+     * 참가자를 추가하고 방의 현재 상태를 응답 객체로 반환합니다.
+     *
+     * @param userId 방에 입장하려는 사용자의 ID
+     * @param gameRoomId 입장하려는 게임 방의 ID
+     * @return 입장한 방의 정보와 현재 참가자 목록을 포함하는 응답 객체
+     * @throws BusinessException 방을 찾을 수 없거나, 이미 시작되었거나, 인원이 가득 찼거나, 중복 입장인 경우 발생
+     */
+    public JoinRoomResponse joinRoom(Long userId, Long gameRoomId) {
+        log.info("User {} attempting to join room {}", userId, gameRoomId);
+
+        // 1. 방 존재 확인
+        GameRoom room = gameRoomRepository.findById(gameRoomId)
+                .orElseThrow(() -> {
+                    log.error("게임 방을 찾을 수 없습니다. gameRoomId={}", gameRoomId);
+                    return new BusinessException(ErrorCode.ROOM_NOT_FOUND);
+                });
+
+        // 2. 방 상태 확인 (WAITING만 입장 가능)
+        if (room.getStatus() != GameRoomStatus.WAITING) {
+            log.warn("이미 시작된 방입니다. gameRoomId={}, status={}", gameRoomId, room.getStatus());
+            throw new BusinessException(ErrorCode.ROOM_ALREADY_STARTED);
+        }
+
+        // 3. 방 인원 확인 (최대 4명)
+        if (room.getCurrentParticipants() >= 4) {
+            log.warn("방 인원이 가득 찼습니다. gameRoomId={}, currentParticipants={}",
+                    gameRoomId, room.getCurrentParticipants());
+            throw new BusinessException(ErrorCode.ROOM_FULL);
+        }
+
+        // 4. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> {
+                    log.error("사용자를 찾을 수 없습니다. userId={}", userId);
+                    return new BusinessException(ErrorCode.USER_NOT_FOUND);
+                });
+
+        // 5. 중복 입장 확인 - WAITING이나 IN_PROGRESS 상태의 방에 참여 중인지 확인
+        boolean alreadyInRoom = participantRepository.existsByParticipantAndGameRoom_StatusIn(
+                user,
+                GameRoomStatus.WAITING,
+                GameRoomStatus.IN_PROGRESS
+        );
+
+        if (alreadyInRoom) {
+            log.warn("이미 다른 방에 참여 중입니다. userId={}", userId);
+            throw new BusinessException(ErrorCode.PARTICIPANT_ALREADY_IN_ROOM);
+        }
+
+        // 6. 참가자 추가
+        GameParticipant participant = GameParticipant.builder()
+                .gameRoom(room)
+                .participant(user)
+                .isHost(false)
+                .build();
+
+        participantRepository.save(participant);
+
+        // 7. 방 인원 증가
+        room.incrementParticipants();
+        gameRoomRepository.save(room);
+
+        // 8. 응답 생성
+        List<GameParticipant> allParticipants = participantRepository.findByGameRoom_Id(gameRoomId);
+        List<ParticipantResponse> participantResponses = allParticipants.stream()
+                .map(ParticipantResponse::from)
+                .toList();
+
+        log.info("User {} successfully joined room {}. currentParticipants={}",
+                userId, gameRoomId, room.getCurrentParticipants());
+
+        return JoinRoomResponse.of(room, participantResponses);
+    }
+}

--- a/backend/src/test/java/app/signbell/backend/controller/gameRoom/GameRoomJoinControllerSpringTest.java
+++ b/backend/src/test/java/app/signbell/backend/controller/gameRoom/GameRoomJoinControllerSpringTest.java
@@ -1,0 +1,200 @@
+package app.signbell.backend.controller.gameRoom;
+
+import app.signbell.backend.dto.common.ApiResponse;
+import app.signbell.backend.dto.request.JoinRoomRequest;
+import app.signbell.backend.dto.response.JoinRoomResponse;
+import app.signbell.backend.dto.response.ParticipantEventResponse;
+import app.signbell.backend.dto.response.ParticipantResponse;
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
+import app.signbell.backend.service.GameRoomJoinService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * GameRoomJoinControllerSpringTest 클래스는 게임 방 참가 컨트롤러(GameRoomJoinController)의
+ * Spring 통합 테스트를 실행하는 클래스입니다.
+ * 주로 WebSocket을 사용한 메시지 전송과 관련된 동작을 검증하며,
+ * 서비스와 컨트롤러 간의 데이터 흐름, 비즈니스 로직 및 에러 처리 동작을 테스트합니다.
+ *
+ * 테스트 시에는 @SpringBootTest와 @MockBean을 사용하여 Spring 컨텍스트를 로드하고,
+ * 실제 의존성을 Mock으로 대체하여 독립적인 테스트 환경을 구성합니다.
+ * 통신 관련 검증은 SimpMessagingTemplate을 Mock으로 설정하고,
+ * ArgumentCaptor를 사용해 메시지 전송의 정확성을 검증합니다.
+ *
+ * 주요 테스트 기능:
+ * 1. 방 참가에 성공한 경우 개인 응답 메시지 전송과 브로드캐스트 메시지 전송을 확인.
+ * 2. 방이 가득 찬 경우 비즈니스 예외(Room Full)에 대한 메시지 처리 검증.
+ * 3. subject가 올바르지 않은 경우 Invalid Input 에러 처리 검증.
+ *
+ * @author 강관주
+ * @since 2025-10-15
+ */
+@SpringBootTest
+@DisplayName("GameRoomJoinController Spring 통합 스타일 단위 테스트")
+class GameRoomJoinControllerSpringTest {
+
+    @Autowired
+    private GameRoomJoinController controller;
+
+    @MockBean
+    private GameRoomJoinService gameRoomJoinService;
+
+    @MockBean
+    private SimpMessagingTemplate messagingTemplate;
+
+    private JoinRoomResponse dummyResponse(Long roomId, int currentParticipants) {
+        ParticipantResponse p1 = ParticipantResponse.builder()
+                .userId(1L)
+                .nickname("u1")
+                .profileImageUrl(null)
+                .isHost(true)
+                .isReady(true)
+                .build();
+        ParticipantResponse p2 = ParticipantResponse.builder()
+                .userId(2L)
+                .nickname("u2")
+                .profileImageUrl(null)
+                .isHost(false)
+                .isReady(false)
+                .build();
+        return JoinRoomResponse.builder()
+                .gameRoomId(roomId)
+                .gameTitle("ROOM")
+                .hostId(1L)
+                .participants(List.of(p1, p2))
+                .currentParticipants(currentParticipants)
+                .maxParticipants(4)
+                .currentRound(1)
+                .status("WAITING")
+                .build();
+    }
+
+    @Test
+    @DisplayName("성공: 개인 응답(/user/queue/room) + 브로드캐스트(/topic/room/{id}/participant) 전송")
+    void joinRoom_success_personal_and_broadcast() {
+        // ============================
+        // Given: 주체/파라미터/서비스 응답 준비
+        // - subject는 인증된 사용자 식별자(@AuthenticationPrincipal)
+        // - service.joinRoom은 JoinRoomResponse를 반환하도록 설정
+        // ============================
+        Long gameRoomId = 10L;
+        String subject = "42";
+        Long userId = 42L;
+        JoinRoomResponse response = dummyResponse(gameRoomId, 2);
+        given(gameRoomJoinService.joinRoom(userId, gameRoomId)).willReturn(response);
+
+        // ============================
+        // When: 컨트롤러의 joinRoom 호출 (WebSocket 없이 직접 메서드 호출)
+        // ============================
+        controller.joinRoom(gameRoomId, new JoinRoomRequest(), subject);
+
+        // ============================
+        // Then: 메시지 전송 검증
+        // 1) 개인 큐로 ApiResponse<JoinRoomResponse> 전송
+        // 2) 브로드캐스트로 ApiResponse<ParticipantEventResponse> 전송
+        // 3) 서비스가 정확한 파라미터로 호출되었는지 검증
+        // ============================
+        ArgumentCaptor<ApiResponse> personalCaptor = ArgumentCaptor.forClass(ApiResponse.class);
+        verify(messagingTemplate).convertAndSendToUser(eq(subject), eq("/queue/room"), personalCaptor.capture());
+        ApiResponse<?> personal = personalCaptor.getValue();
+        assertThat(personal).isNotNull();
+        assertThat(personal.isSuccess()).isTrue();
+        assertThat(personal.getData()).isInstanceOf(JoinRoomResponse.class);
+        assertThat((JoinRoomResponse) personal.getData()).isSameAs(response);
+
+        ArgumentCaptor<ApiResponse> broadcastCaptor = ArgumentCaptor.forClass(ApiResponse.class);
+        verify(messagingTemplate).convertAndSend(eq("/topic/room/" + gameRoomId + "/participant"), broadcastCaptor.capture());
+        ApiResponse<?> broadcast = broadcastCaptor.getValue();
+        assertThat(broadcast).isNotNull();
+        assertThat(broadcast.isSuccess()).isTrue();
+        assertThat(broadcast.getData()).isInstanceOf(ParticipantEventResponse.class);
+        ParticipantEventResponse event = (ParticipantEventResponse) broadcast.getData();
+        assertThat(event.getEventType()).isEqualTo("PARTICIPANT_JOINED");
+        assertThat(event.getCurrentParticipants()).isEqualTo(response.getCurrentParticipants());
+        ParticipantResponse expectedLast = response.getParticipants().get(response.getParticipants().size() - 1);
+        assertThat(event.getParticipant().getUserId()).isEqualTo(expectedLast.getUserId());
+
+        verify(gameRoomJoinService).joinRoom(userId, gameRoomId);
+        verifyNoMoreInteractions(gameRoomJoinService, messagingTemplate);
+    }
+
+    @Test
+    @DisplayName("비즈니스 예외: ROOM_FULL이면 개인 큐(/user/queue/errors)로 ErrorResponse 전송")
+    void joinRoom_businessException_errorToUser() {
+        // ============================
+        // Given: 서비스가 BusinessException(ROOM_FULL)을 던지도록 설정
+        // ============================
+        Long gameRoomId = 20L;
+        String subject = "42";
+        Long userId = 42L;
+        given(gameRoomJoinService.joinRoom(userId, gameRoomId))
+                .willThrow(new BusinessException(ErrorCode.ROOM_FULL));
+
+        // ============================
+        // When: 컨트롤러 호출
+        // ============================
+        controller.joinRoom(gameRoomId, new JoinRoomRequest(), subject);
+
+        // ============================
+        // Then: 에러 응답이 개인 큐로 전송되며, ErrorResponse 필드가 올바른지 확인
+        // ============================
+        ArgumentCaptor<Object> errorCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(messagingTemplate).convertAndSendToUser(eq(subject), eq("/queue/errors"), errorCaptor.capture());
+        Object payload = errorCaptor.getValue();
+        assertThat(payload).isInstanceOf(app.signbell.backend.exception.dto.ErrorResponse.class);
+        app.signbell.backend.exception.dto.ErrorResponse err =
+                (app.signbell.backend.exception.dto.ErrorResponse) payload;
+        assertThat(err.getStatus()).isEqualTo(ErrorCode.ROOM_FULL.getStatus());
+        assertThat(err.getError()).isEqualTo(ErrorCode.ROOM_FULL.getCode());
+        assertThat(err.getDetail()).isEqualTo(ErrorCode.ROOM_FULL.getMessage());
+
+        verify(gameRoomJoinService).joinRoom(userId, gameRoomId);
+        verifyNoMoreInteractions(gameRoomJoinService, messagingTemplate);
+    }
+
+    @Test
+    @DisplayName("subject 파싱 실패: INVALID_INPUT 에러가 개인 큐로 전송되고 서비스는 호출되지 않음")
+    void joinRoom_invalidSubject_errorToUser() {
+        // ============================
+        // Given: 숫자가 아닌 subject 값 준비
+        // ============================
+        Long gameRoomId = 30L;
+        String subject = "not-a-number";
+
+        // ============================
+        // When: 컨트롤러 호출
+        // ============================
+        controller.joinRoom(gameRoomId, new JoinRoomRequest(), subject);
+
+        // ============================
+        // Then: 서비스 미호출 + INVALID_INPUT ErrorResponse 전송 검증
+        // ============================
+        verify(gameRoomJoinService, never()).joinRoom(anyLong(), anyLong());
+
+        ArgumentCaptor<Object> errorCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(messagingTemplate).convertAndSendToUser(eq(subject), eq("/queue/errors"), errorCaptor.capture());
+        Object payload = errorCaptor.getValue();
+        assertThat(payload).isInstanceOf(app.signbell.backend.exception.dto.ErrorResponse.class);
+        app.signbell.backend.exception.dto.ErrorResponse err =
+                (app.signbell.backend.exception.dto.ErrorResponse) payload;
+        assertThat(err.getStatus()).isEqualTo(ErrorCode.INVALID_INPUT.getStatus());
+        assertThat(err.getError()).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
+        assertThat(err.getDetail()).isEqualTo(ErrorCode.INVALID_INPUT.getMessage());
+
+        verifyNoMoreInteractions(gameRoomJoinService, messagingTemplate);
+    }
+}

--- a/backend/src/test/java/app/signbell/backend/repository/GameParticipantRepositoryNPlusOneTest.java
+++ b/backend/src/test/java/app/signbell/backend/repository/GameParticipantRepositoryNPlusOneTest.java
@@ -1,0 +1,170 @@
+package app.signbell.backend.repository;
+
+import app.signbell.backend.entity.*;
+import jakarta.persistence.EntityManagerFactory;
+import org.hibernate.SessionFactory;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * GameParticipantRepositoryNPlusOneTest 클래스는 GameParticipantRepository에 대한
+ * N+1 문제 방지를 검증하는 테스트를 수행하기 위한 클래스입니다.
+ *
+ * 주요 목적:
+ * - Repository 레이어의 쿼리를 실행한 결과가 N+1 문제를 발생시키지 않는지 확인합니다.
+ * - GameParticipant 엔티티와 연관된 User 및 GameRoom 엔티티의 조회가 최적화되었는지 검증합니다.
+ *
+ * 주요 구성:
+ * - @SpringBootTest: Spring Boot 애플리케이션 컨텍스트를 로드하여 통합 테스트 실행.
+ * - @Transactional: 각 테스트 후 데이터 롤백을 보장하여 데이터 정합성을 유지.
+ * - @DisplayName: 테스트 의도를 명시적으로 설명.
+ *
+ * 사용된 테스트 시나리오:
+ * 1. GameRoom ID를 기준으로 GameParticipant를 조회하는 findByGameRoom_Id 메서드의 N+1 문제 여부를 검증.
+ * 2. 특정 User ID를 기준으로 GameParticipant를 조회하는 findByParticipant_Id 메서드의 N+1 문제 여부를 검증.
+ *
+ * 테스트 환경 세팅:
+ * - 데이터 초기화를 위한 @BeforeEach 메서드 제공.
+ * - Hibernate 통계 API를 활용하여 실행된 쿼리 횟수를 측정 및 검증.
+ *
+ * 이 테스트는 GameParticipant와 연관된 엔티티를 JOIN FETCH 방식으로 조회하며,
+ * 불필요한 추가 쿼리가 발생하지 않는지 확인합니다.
+ *
+ * @author 강관주
+ * @since 2025-10-15
+ */
+@SpringBootTest
+@Transactional
+@DisplayName("GameParticipantRepository N+1 검증 테스트")
+class GameParticipantRepositoryNPlusOneTest {
+
+    @Autowired
+    private GameParticipantRepository gameParticipantRepository;
+
+    @Autowired
+    private GameRoomRepository gameRoomRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private EntityManagerFactory emf;
+
+    private User host;
+
+    @BeforeEach
+    void init() {
+        host = userRepository.save(User.builder()
+                .nickname("host")
+                .email("host@example.com")
+                .provider(LoginMethod.KAKAO)
+                .providerId("host-1")
+                .build());
+    }
+
+    private Statistics enableAndClearStats() {
+        SessionFactory sf = emf.unwrap(SessionFactory.class);
+        Statistics stats = sf.getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+        return stats;
+    }
+
+    @Test
+    @DisplayName("findByGameRoom_Id: 참가자 User를 JOIN FETCH 하므로 N+1 없이 1회 조회로 충분해야 한다")
+    void findByGameRoom_Id_should_not_trigger_NPlusOne() {
+        // Given: 방 1개와 참가자 10명 생성
+        GameRoom room = gameRoomRepository.save(GameRoom.builder()
+                .gameTitle("ROOM-1")
+                .host(host)
+                .status(GameRoomStatus.WAITING)
+                .build());
+
+        List<User> users = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            users.add(userRepository.save(User.builder()
+                    .nickname("user-" + i)
+                    .email("user" + i + "@example.com")
+                    .provider(LoginMethod.KAKAO)
+                    .providerId("u-" + i)
+                    .build()));
+        }
+
+        // 호스트 자신도 참가자로 추가
+        gameParticipantRepository.save(GameParticipant.builder()
+                .gameRoom(room)
+                .participant(host)
+                .isHost(true)
+                .build());
+        for (User u : users) {
+            gameParticipantRepository.save(GameParticipant.builder()
+                    .gameRoom(room)
+                    .participant(u)
+                    .isHost(false)
+                    .build());
+        }
+
+        // When: 통계 초기화 후 조회 실행
+        Statistics stats = enableAndClearStats();
+        List<GameParticipant> participants = gameParticipantRepository.findByGameRoom_Id(room.getId());
+
+        // 연관 엔티티 실제 접근 (지연 로딩이 있다면 여기서 추가 쿼리 발생)
+        for (GameParticipant gp : participants) {
+            gp.getParticipant().getNickname();
+        }
+
+        // Then: SELECT 쿼리는 단 1회여야 함 (JOIN FETCH로 N+1 방지)
+        long queryCount = stats.getPrepareStatementCount();
+        assertThat(queryCount)
+                .as("JOIN FETCH로 한 번의 SELECT만 실행되어야 합니다. 실제 쿼리 수: " + queryCount)
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("findByParticipant_Id: GameRoom과 User를 JOIN FETCH 하므로 추가 쿼리 없이 1회여야 한다")
+    void findByParticipant_Id_should_not_trigger_NPlusOne() {
+        // Given: 방 1개 + 특정 참가자 1명
+        GameRoom room = gameRoomRepository.save(GameRoom.builder()
+                .gameTitle("ROOM-2")
+                .host(host)
+                .status(GameRoomStatus.WAITING)
+                .build());
+
+        User target = userRepository.save(User.builder()
+                .nickname("target")
+                .email("target@example.com")
+                .provider(LoginMethod.KAKAO)
+                .providerId("target-1")
+                .build());
+
+        gameParticipantRepository.save(GameParticipant.builder()
+                .gameRoom(room)
+                .participant(target)
+                .isHost(false)
+                .build());
+
+        // When: 통계 초기화 후 조회 실행
+        Statistics stats = enableAndClearStats();
+        GameParticipant gp = gameParticipantRepository.findByParticipant_Id(target.getId()).orElseThrow();
+
+        // 연관 엔티티 실제 접근
+        gp.getParticipant().getNickname();
+        gp.getGameRoom().getGameTitle();
+
+        // Then: SELECT 쿼리는 단 1회여야 함
+        long queryCount = stats.getPrepareStatementCount();
+        assertThat(queryCount)
+                .as("JOIN FETCH로 한 번의 SELECT만 실행되어야 합니다. 실제 쿼리 수: " + queryCount)
+                .isEqualTo(1);
+    }
+}

--- a/backend/src/test/java/app/signbell/backend/service/GameRoomJoinServiceTest.java
+++ b/backend/src/test/java/app/signbell/backend/service/GameRoomJoinServiceTest.java
@@ -1,0 +1,167 @@
+package app.signbell.backend.service;
+
+import app.signbell.backend.dto.response.JoinRoomResponse;
+import app.signbell.backend.entity.*;
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
+import app.signbell.backend.repository.GameParticipantRepository;
+import app.signbell.backend.repository.GameRoomRepository;
+import app.signbell.backend.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.*;
+
+/**
+ * GameRoomJoinServiceTest 클래스는 GameRoomJoinService의 통합 테스트를 수행합니다.
+ *
+ * 이 클래스는 다음과 같은 테스트 시나리오를 포함합니다:
+ * 1. 정상적인 방 입장 처리 및 상태 확인.
+ * 2. 존재하지 않는 게임 방 입장 시도.
+ * 3. 존재하지 않는 사용자의 방 입장 시도.
+ * 4. 이미 시작된 게임 방 입장 시도.
+ * 5. 방이 이미 최대 인원에 도달한 경우 입장 시도.
+ * 6. 사용자가 다른 대기/진행 중인 방에 참여 중인 경우의 입장 시도.
+ *
+ * 위 테스트는 GameRoomRepository, GameParticipantRepository, UserRepository와의 상호 작용,
+ * 예외 처리 로직, 서비스의 주요 비즈니스 로직 검증을 목표로 합니다.
+ *
+ * 테스트는 @SpringBootTest 및 @Transactional로 설정되어 있으며, 테스트 실행 시 데이터베이스 상태가 롤백됩니다.
+ *
+ * @author 강관주
+ * @since 2025-10-15
+ */
+@SpringBootTest
+@Transactional
+@DisplayName("GameRoomJoinService 통합 테스트")
+class GameRoomJoinServiceTest {
+
+    @Autowired
+    private GameRoomJoinService service;
+
+    @Autowired
+    private GameRoomRepository gameRoomRepository;
+
+    @Autowired
+    private GameParticipantRepository participantRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User createUser(String name) {
+        return userRepository.save(User.builder()
+                .nickname(name)
+                .email(name + "@example.com")
+                .provider(LoginMethod.KAKAO)
+                .providerId("pid-" + name)
+                .build());
+    }
+
+    private GameRoom createRoom(String title, User host, GameRoomStatus status) {
+        return gameRoomRepository.save(GameRoom.builder()
+                .gameTitle(title)
+                .host(host)
+                .status(status)
+                .build());
+    }
+
+    @Test
+    @DisplayName("대기 중 방에 정상 입장하면 참가자 추가 및 인원 수 증가")
+    void joinRoom_success() {
+        // Given
+        User host = createUser("host");
+        GameRoom room = createRoom("ROOM", host, GameRoomStatus.WAITING);
+        User user = createUser("guest");
+
+        // When
+        JoinRoomResponse res = service.joinRoom(user.getId(), room.getId());
+
+        // Then
+        assertThat(res.getGameRoomId()).isEqualTo(room.getId());
+        assertThat(res.getStatus()).isEqualTo(GameRoomStatus.WAITING.name());
+        assertThat(res.getCurrentParticipants()).isEqualTo(2);
+        assertThat(res.getParticipants()).extracting("userId").contains(user.getId());
+        assertThat(participantRepository.countByGameRoom_Id(room.getId())).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 방이면 ROOM_NOT_FOUND")
+    void joinRoom_roomNotFound() {
+        // Given
+        User user = createUser("user");
+
+        // When & Then
+        assertThatThrownBy(() -> service.joinRoom(user.getId(), -1L))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자면 USER_NOT_FOUND")
+    void joinRoom_userNotFound() {
+        // Given
+        User host = createUser("host");
+        GameRoom room = createRoom("ROOM", host, GameRoomStatus.WAITING);
+
+        // When & Then
+        assertThatThrownBy(() -> service.joinRoom(-1L, room.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("이미 시작된 방이면 ROOM_ALREADY_STARTED")
+    void joinRoom_roomAlreadyStarted() {
+        // Given
+        User host = createUser("host");
+        GameRoom room = createRoom("ROOM", host, GameRoomStatus.IN_PROGRESS);
+        User user = createUser("user");
+
+        // When & Then
+        assertThatThrownBy(() -> service.joinRoom(user.getId(), room.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_ALREADY_STARTED);
+    }
+
+    @Test
+    @DisplayName("방이 가득 차면 ROOM_FULL")
+    void joinRoom_roomFull() {
+        // Given
+        User host = createUser("host");
+        GameRoom room = createRoom("ROOM", host, GameRoomStatus.WAITING);
+        room.incrementParticipants();
+        room.incrementParticipants();
+        room.incrementParticipants();
+        gameRoomRepository.save(room);
+        User user = createUser("user");
+
+        // When & Then
+        assertThatThrownBy(() -> service.joinRoom(user.getId(), room.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_FULL);
+    }
+
+    @Test
+    @DisplayName("사용자가 다른 대기/진행중 방에 참여 중이면 PARTICIPANT_ALREADY_IN_ROOM")
+    void joinRoom_participantAlreadyInAnotherRoom() {
+        // Given
+        User host = createUser("host");
+        GameRoom targetRoom = createRoom("TARGET", host, GameRoomStatus.WAITING);
+        User user = createUser("user");
+
+        GameRoom otherRoom = createRoom("OTHER", host, GameRoomStatus.WAITING);
+        participantRepository.save(GameParticipant.builder()
+                .gameRoom(otherRoom)
+                .participant(user)
+                .isHost(false)
+                .build());
+
+        // When & Then
+        assertThatThrownBy(() -> service.joinRoom(user.getId(), targetRoom.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.PARTICIPANT_ALREADY_IN_ROOM);
+    }
+}


### PR DESCRIPTION
# Pull Request

## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요. (선택된 항목은 자동 라벨링됩니다)
- [x] 기능 (Feature)
- [ ] 버그 수정 (Bugfix)
- [ ] 기능 개선 (Enhancement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
> 이 PR이 무엇을 하는지 한눈에 파악할 수 있도록 핵심 내용을 요약합니다.

WebSocket(STOMP) 기반의 퀴즈 방 입장 기능을 추가했습니다.  
서버는 `/app/room/{gameRoomId}/join` 요청을 처리하여 방 상태 검증(존재/진행 상태/인원/중복 입장) 후, 입장자 개인 큐(`/user/queue/room`)로 방 전체 정보를 전달하고, 방 전체 토픽(`/topic/room/{gameRoomId}/participant`)으로 신규 참가자 이벤트를 브로드캐스트합니다.  
Repository의 JPQL fetch join 적용으로 N+1 문제를 방지했으며, Service/Controller 계층에 대한 통합 테스트를 추가했습니다.

---

## 관련 이슈 (Related Issue)
> 이 PR과 관련된 이슈 번호를 작성해주세요.  
> (예: Closes #10, Fixes #11, Resolves #12, Relates to #13)

- Closes #23

---

## 변경 사항 (Changes)
> 이 PR로 인해 변경된 점을 상세히 서술합니다.

- DTO 추가 및 정리
  - `JoinRoomRequest`, `JoinRoomResponse`, `ParticipantResponse`, `ParticipantEventResponse` 추가로 요청/응답 명세 확립. (커밋 1, 3, 4)

- Entity 편의 메서드
  - `GameRoom.incrementParticipants()`, `decrementParticipants()` 추가로 상태 관리 단순화. (커밋 1)

- Repository 최적화
  - `GameParticipantRepository`에 JPQL fetch join 적용
    - `findByGameRoom_Id` 즉시 로딩으로 N+1 방지
    - `findByParticipant_Id`에서 GameRoom/User 함께 fetch. (커밋 2)
  - 참가자 조회/카운팅/중복 확인 메서드 추가. (커밋 1)

- Service 계층
  - `GameRoomJoinService` 도입
    - 방 존재/상태 검증(WAITING), 인원 제한(최대 4명), 중복 입장 방지
    - 참가자 추가 및 방 상태 업데이트
    - 예외는 `BusinessException`을 통해 일관 처리
    - 로깅으로 추적성 강화. (커밋 3)

- Controller 계층
  - `GameRoomJoinController` 추가
    - STOMP 엔드포인트에서 개인 큐 응답(`/user/queue/room`) 및 브로드캐스트(`/topic/room/{gameRoomId}/participant`) 처리
    - 사용자별 에러 메시지 전송 로직 포함. (커밋 4)

- 테스트
  - Repository 레벨에서 N+1 방지 검증 테스트 추가. (커밋 5)
  - `GameRoomJoinService` 통합 테스트
    - 정상 입장, 방/사용자 미존재, 이미 시작된 방, 인원 초과, 타 방 참여 중 등. (커밋 6)
  - `GameRoomJoinController` 통합 테스트
    - 성공 시 개인 큐/브로드캐스트 메시지 검증
    - ROOM_FULL, INVALID_INPUT 등 에러 시나리오 검증
    - `@SpringBootTest`, `@MockBean`, `ArgumentCaptor` 활용. (커밋 7)

---

## 스크린샷 (Screenshots) (Optional)
> UI/UX 변경 사항이 있다면, 변경 전후 스크린샷을 첨부해주세요.

(해당 없음)

---

## 테스트 방법 (Test Steps)
> 리뷰어가 이 변경 사항을 로컬에서 직접 검증할 수 있도록 구체적인 절차를 작성해주세요.
1. 백엔드 애플리케이션을 로컬에서 실행합니다. (WebSocket/STOMP 설정 포함)
2. 클라이언트에서 STOMP로 접속 후 구독 설정
   - `/user/queue/room`, `/user/queue/errors`, `/topic/room/{gameRoomId}/participant`
3. 다음 메시지를 전송하여 방 입장을 시도합니다.
   - SEND to `/app/room/{gameRoomId}/join`
   - payload: `{ "gameRoomId": <테스트 방 ID> }`
4. 기대 결과
   - 개인 큐(`/user/queue/room`)로 방 전체 정보 수신
   - 토픽(`/topic/room/{gameRoomId}/participant`)에 신규 참가자 이벤트 브로드캐스트
5. 에러 시나리오 검증
   - 존재하지 않는 방 ID
   - 이미 시작된 방
   - 인원 초과 상태
   - 다른 방에 이미 참여 중인 사용자
   - 각 경우 `/user/queue/errors`로 에러 응답 수신 확인
6. 통합 테스트 실행
   - `GameParticipantRepository`, `GameRoomJoinService`, `GameRoomJoinController` 관련 테스트가 성공하는지 확인

---

## 셀프 체크리스트 (Self-Checklist)
> 리뷰 요청 전, 아래 항목을 확인해주세요.
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [ ] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)
> 리뷰어가 특별히 더 신경 써서 봐야 할 부분이나 참고사항을 작성해주세요.  
> (예: 성능 최적화 부분 집중 검토 필요, API 스펙 변경 사항 확인 요청 등)

- 성능: Repository의 JPQL fetch join으로 N+1이 제거되었는지 추가 관찰 부탁드립니다.
- API/메시징: 개인 큐/브로드캐스트 대상 및 경로가 요구사항과 일치하는지 확인 부탁드립니다.
- 예외 처리: INVALID_INPUT, ROOM_FULL, 이미 시작된 방 등 에러 코드/메시지 일관성을 봐주세요.
- 테스트: 통합 테스트 시나리오가 충분한지, 추가 케이스 제안 환영합니다.