### PR TITLE
[Feat]: 개인 학습용 조회 API 구현 및 통합 수어 데이터 관리 기능 (#36, #37, #39)

### DIFF
--- a/backend/src/main/java/app/signbell/backend/controller/SignStatusController.java
+++ b/backend/src/main/java/app/signbell/backend/controller/SignStatusController.java
@@ -1,0 +1,33 @@
+// app.signbell.backend.controller 패키지에 생성
+package app.signbell.backend.controller;
+
+import app.signbell.backend.dto.request.QuizWordUpdateRequest;
+import app.signbell.backend.service.SignService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/signs")
+@RequiredArgsConstructor
+public class SignStatusController {
+
+    private final SignService signService;
+
+    /**
+     * 특정 수어 데이터의 학습 상태를 업데이트합니다.
+     * ML 모델이 학습 완료 후 이 API를 호출하여 상태를 'COMPLETED'로 변경할 수 있습니다.
+     *
+     * @param signId 상태를 변경할 Sign 데이터의 ID
+     * @param request 새로운 상태 정보를 담은 DTO
+     * @return 성공 시 200 OK
+     */
+    @PatchMapping("/{signId}/status")
+    public ResponseEntity<Void> updateLearningStatus(
+            @PathVariable Long signId,
+            @RequestBody QuizWordUpdateRequest request
+    ) {
+        signService.updateLearningStatus(signId, request.getNewStatus());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/controller/SignStatusController.java
+++ b/backend/src/main/java/app/signbell/backend/controller/SignStatusController.java
@@ -2,6 +2,9 @@
 package app.signbell.backend.controller;
 
 import app.signbell.backend.dto.request.QuizWordUpdateRequest;
+import app.signbell.backend.dto.response.QuizWordUpdateResponse;
+import app.signbell.backend.entity.Sign;
+import app.signbell.backend.entity.SignStatus;
 import app.signbell.backend.service.SignService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,16 +21,38 @@ public class SignStatusController {
      * 특정 수어 데이터의 학습 상태를 업데이트합니다.
      * ML 모델이 학습 완료 후 이 API를 호출하여 상태를 'COMPLETED'로 변경할 수 있습니다.
      *
-     * @param signId 상태를 변경할 Sign 데이터의 ID
+     * @param signId  상태를 변경할 Sign 데이터의 ID
      * @param request 새로운 상태 정보를 담은 DTO
      * @return 성공 시 200 OK
+     * @since 2025-10-16
+     * @author 백승현
      */
-    @PatchMapping("/{signId}/status")
-    public ResponseEntity<Void> updateLearningStatus(
-            @PathVariable Long signId,
-            @RequestBody QuizWordUpdateRequest request
-    ) {
-        signService.updateLearningStatus(signId, request.getNewStatus());
-        return ResponseEntity.ok().build();
+    /**
+     * 특정 수어 데이터의 학습 상태를 '완료(COMPLETED)'로 변경합니다.
+     */
+    @PostMapping("/{signId}/complete")
+    public ResponseEntity<QuizWordUpdateResponse> markAsCompleted(@PathVariable Long signId) {
+        Sign updatedSign = signService.updateLearningStatus(signId, SignStatus.COMPLETED);
+        return ResponseEntity.ok(new QuizWordUpdateResponse(updatedSign));
     }
+
+    /**
+     * 특정 수어 데이터의 학습 상태를 '진행중(IN_PROGRESS)'으로 변경합니다.
+     */
+    @PostMapping("/{signId}/start-progress")
+    public ResponseEntity<QuizWordUpdateResponse> markAsInProgress(@PathVariable Long signId) {
+        Sign updatedSign = signService.updateLearningStatus(signId, SignStatus.IN_PROGRESS);
+        return ResponseEntity.ok(new QuizWordUpdateResponse(updatedSign));
+    }
+
+    /**
+     * 특정 수어 데이터의 학습 상태를 '미진행(PENDING)'으로 초기화합니다.
+     */
+    @PostMapping("/{signId}/reset")
+    public ResponseEntity<QuizWordUpdateResponse> markAsPending(@PathVariable Long signId) {
+        Sign updatedSign = signService.updateLearningStatus(signId, SignStatus.PENDING);
+        return ResponseEntity.ok(new QuizWordUpdateResponse(updatedSign));
+    }
+
+
 }

--- a/backend/src/main/java/app/signbell/backend/controller/signData/SignDataController.java
+++ b/backend/src/main/java/app/signbell/backend/controller/signData/SignDataController.java
@@ -1,29 +1,31 @@
-// app.signbell.backend.controller 패키지에 생성
-package app.signbell.backend.controller;
+package app.signbell.backend.controller.signData;
 
-import app.signbell.backend.dto.request.QuizWordUpdateRequest;
+
 import app.signbell.backend.dto.response.QuizWordUpdateResponse;
+import app.signbell.backend.dto.response.signData.SignDataLoadResponseDto;
 import app.signbell.backend.entity.Sign;
 import app.signbell.backend.entity.SignStatus;
+import app.signbell.backend.service.SignApiService;
 import app.signbell.backend.service.SignService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/signs")
+@RequestMapping("/api/sign-data")
 @RequiredArgsConstructor
-public class SignStatusController {
+public class SignDataController {
 
     private final SignService signService;
+    private final SignApiService signApiService;
 
     /**
+     *
+     * 외부 API의 수어 데이터를 프로젝트에 맞게 정제하고,
      * 특정 수어 데이터의 학습 상태를 업데이트합니다.
+     *
      * ML 모델이 학습 완료 후 이 API를 호출하여 상태를 'COMPLETED'로 변경할 수 있습니다.
      *
-     * @param signId  상태를 변경할 Sign 데이터의 ID
-     * @param request 새로운 상태 정보를 담은 DTO
-     * @return 성공 시 200 OK
      * @since 2025-10-16
      * @author 백승현
      */
@@ -54,5 +56,9 @@ public class SignStatusController {
         return ResponseEntity.ok(new QuizWordUpdateResponse(updatedSign));
     }
 
-
+    @GetMapping("/getApiData")
+    public ResponseEntity<SignDataLoadResponseDto> getApiData() {
+        long count = signApiService.fetchAllSignDataAndSave();
+        return ResponseEntity.ok(new SignDataLoadResponseDto(count));
+    }
 }

--- a/backend/src/main/java/app/signbell/backend/controller/signEdu/SignEduController.java
+++ b/backend/src/main/java/app/signbell/backend/controller/signEdu/SignEduController.java
@@ -1,0 +1,62 @@
+package app.signbell.backend.controller.signEdu;
+
+import app.signbell.backend.dto.response.signEdu.SignDetailResponseDto;
+import app.signbell.backend.dto.response.signEdu.SignSimpleResponseDto;
+import app.signbell.backend.service.SignEduService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 수어 학습 콘텐츠 조회 API를 제공하는 컨트롤러입니다.
+ */
+@RestController
+@RequestMapping("/api/sign-edu")
+@RequiredArgsConstructor
+public class SignEduController {
+
+    private final SignEduService signEduService;
+
+    /**
+     * 모든 카테고리 목록을 조회하는 API
+     * @return 카테고리 문자열 리스트
+     */
+    @GetMapping("/categories")
+    public ResponseEntity<List<String>> getAllCategoryTypes() {
+        List<String> categoryTypes = signEduService.findAllCategoryTypes();
+        return ResponseEntity.ok(categoryTypes);
+    }
+
+    /**
+     * 모든 단어 또는 특정 카테고리의 단어 목록을 페이징하여 조회하는 API
+     * @param category 카테고리명 (선택적 쿼리 파라미터)
+     * @param pageable 페이징 정보
+     *                 /api/sign-edu?category=삶
+     *                 /api/sign-edu?category=삶&page=2
+     * @return 단어 간략 정보의 Page 객체
+     */
+    @GetMapping
+    public ResponseEntity<Page<SignSimpleResponseDto>> getSigns(
+            @RequestParam(value = "category", required = false) String category,
+            @PageableDefault(size = 20, sort = "title") Pageable pageable) {
+        Page<SignSimpleResponseDto> signsPage = signEduService.findSigns(category, pageable);
+        return ResponseEntity.ok(signsPage);
+    }
+
+    /**
+     * 특정 단어의 상세 정보를 조회하는 API
+     * @param signId 단어 ID (경로 변수)
+     * @return 단어 상세 정보
+     */
+    @GetMapping("/{signId}")
+    public ResponseEntity<SignDetailResponseDto> getSignDetails(
+            @PathVariable("signId") Long signId) {
+        SignDetailResponseDto signDetails = signEduService.findSignById(signId);
+        return ResponseEntity.ok(signDetails);
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/dto/request/QuizWordUpdateRequest.java
+++ b/backend/src/main/java/app/signbell/backend/dto/request/QuizWordUpdateRequest.java
@@ -1,0 +1,16 @@
+package app.signbell.backend.dto.request;
+
+import app.signbell.backend.entity.SignStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+/**
+ * 학습 상태가 완료인 단어를 QuizWord에 업데이트하기 위한 요청 DTO입니다.
+ *
+ * @since 2025-10-16
+ * @author 백승현
+ */
+@Getter
+@NoArgsConstructor
+public class QuizWordUpdateRequest {
+    private SignStatus newStatus;
+}

--- a/backend/src/main/java/app/signbell/backend/dto/response/QuizWordUpdateResponse.java
+++ b/backend/src/main/java/app/signbell/backend/dto/response/QuizWordUpdateResponse.java
@@ -1,0 +1,23 @@
+// app.signbell.backend.dto.response 패키지에 생성
+package app.signbell.backend.dto.response;
+
+import app.signbell.backend.entity.Sign;
+import app.signbell.backend.entity.SignStatus;
+import lombok.Getter;
+
+@Getter
+public class QuizWordUpdateResponse {
+
+    private final Long signId;
+    private final String title;
+    private final SignStatus newStatus;
+    private final String message;
+
+    public QuizWordUpdateResponse(Sign sign) {
+        this.signId = sign.getId();
+        this.title = sign.getTitle();
+        this.newStatus = sign.getLearningStatus();
+        this.message = String.format("ID %d번 단어 '%s'의 상태가 '%s'(으)로 성공적으로 업데이트되었습니다.",
+                sign.getId(), sign.getTitle(), sign.getLearningStatus().getKoreanName());
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/dto/response/SignApiResponse.java
+++ b/backend/src/main/java/app/signbell/backend/dto/response/SignApiResponse.java
@@ -1,0 +1,116 @@
+package app.signbell.backend.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 외부 수어 데이터 API의 JSON 응답을 매핑하기 위한 DTO 클래스입니다.
+ * 중첩된 JSON 구조를 표현하기 위해 여러 static inner class로 구성됩니다.
+ *
+ * @author 백승현
+ * @since 2025-10-16
+ */
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true) // JSON에 있는데 클래스에 없는 필드는 무시
+public class SignApiResponse {
+    private Response response;
+
+    @JsonCreator
+    public SignApiResponse(@JsonProperty("response") Response response) {
+        this.response = response;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Response {
+        private ResponseHeader header;
+        private ResponseBody body;
+
+        @JsonCreator
+        public Response(
+                @JsonProperty("header") ResponseHeader header,
+                @JsonProperty("body") ResponseBody body) {
+            this.header = header;
+            this.body = body;
+        }
+
+        @Getter
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class ResponseHeader {
+            private String resultCode;
+            private String resultMsg;
+
+            @JsonCreator
+            public ResponseHeader(
+                    @JsonProperty("resultCode") String resultCode,
+                    @JsonProperty("resultMsg") String resultMsg) {
+                this.resultCode = resultCode;
+                this.resultMsg = resultMsg;
+            }
+        }
+
+        @Getter
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class ResponseBody {
+            private Items items;
+            private String numOfRows;
+            private String pageNo;
+            private String totalCount;
+
+            @JsonCreator
+            public ResponseBody(
+                    @JsonProperty("items") Items items,
+                    @JsonProperty("numOfRows") String numOfRows,
+                    @JsonProperty("pageNo") String pageNo,
+                    @JsonProperty("totalCount") String totalCount) {
+                this.items = items;
+                this.numOfRows = numOfRows;
+                this.pageNo = pageNo;
+                this.totalCount = totalCount;
+            }
+
+            @Getter
+            @NoArgsConstructor
+            @JsonIgnoreProperties(ignoreUnknown = true)
+            public static class Items {
+                private List<Item> item;
+
+                @JsonCreator
+                public Items(@JsonProperty("item") List<Item> item) {
+                    this.item = item;
+                }
+
+                @Getter
+                @NoArgsConstructor
+                @JsonIgnoreProperties(ignoreUnknown = true)
+                public static class Item {
+                    private String title;
+                    private String url;
+                    private String signDescription; // << ✨ 추가된 필드
+                    private String categoryType;
+
+                    @JsonCreator
+                    public Item(
+                            @JsonProperty("title") String title,
+                            @JsonProperty("url") String url,
+                            @JsonProperty("signDescription") String signDescription, // << ✨ 추가
+                            @JsonProperty("categoryType") String categoryType) {
+                        this.title = title;
+                        this.url = url;
+                        this.signDescription = signDescription; // << ✨ 추가
+                        this.categoryType = categoryType;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/dto/response/signData/SignDataLoadResponseDto.java
+++ b/backend/src/main/java/app/signbell/backend/dto/response/signData/SignDataLoadResponseDto.java
@@ -1,0 +1,21 @@
+package app.signbell.backend.dto.response.signData;
+
+import lombok.Getter;
+
+/**
+ * 외부 API로부터 수어 데이터를 로드한 후의 응답을 위한 DTO입니다.
+ * 로드된 데이터의 개수와 결과 메시지를 포함합니다.
+ * @since 2025-10-16
+ * @author 백승현
+ */
+@Getter
+public class SignDataLoadResponseDto {
+
+    private final long loadedCount;
+    private final String message;
+
+    public SignDataLoadResponseDto(long loadedCount) {
+        this.loadedCount = loadedCount;
+        this.message = loadedCount + "개의 수어 데이터가 성공적으로 로드되었습니다.";
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/dto/response/signEdu/SignDetailResponseDto.java
+++ b/backend/src/main/java/app/signbell/backend/dto/response/signEdu/SignDetailResponseDto.java
@@ -1,0 +1,26 @@
+package app.signbell.backend.dto.response.signEdu;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 단일 단어 상세 정보 조회 시 사용되는 응답 DTO입니다.
+ */
+@Getter
+public class SignDetailResponseDto {
+
+    private final Long signId;
+    private final String wordName;
+    private final String description;
+    private final String videoUrl;
+    private final String tag; // API 응답에서는 'tag'라는 이름으로 categoryType을 제공
+
+    @Builder
+    public SignDetailResponseDto(Long signId, String wordName, String description, String videoUrl, String tag) {
+        this.signId = signId;
+        this.wordName = wordName;
+        this.description = description;
+        this.videoUrl = videoUrl;
+        this.tag = tag;
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/dto/response/signEdu/SignSimpleResponseDto.java
+++ b/backend/src/main/java/app/signbell/backend/dto/response/signEdu/SignSimpleResponseDto.java
@@ -1,0 +1,20 @@
+package app.signbell.backend.dto.response.signEdu;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 카테고리별 단어 목록 조회 시 사용되는 간단한 응답 DTO입니다.
+ */
+@Getter
+public class SignSimpleResponseDto {
+
+    private final Long signId;
+    private final String wordName;
+
+    @Builder
+    public SignSimpleResponseDto(Long signId, String wordName) {
+        this.signId = signId;
+        this.wordName = wordName;
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/entity/QuizWord.java
+++ b/backend/src/main/java/app/signbell/backend/entity/QuizWord.java
@@ -2,37 +2,42 @@ package app.signbell.backend.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
  * QuizWord 클래스는 퀴즈에 사용하는 단어 정보를 관리하는 엔티티입니다.
- * 해당 클래스는 데이터베이스의 quiz_word 테이블과 매핑되며,
- * 퀴즈 단어 ID 및 관련된 SignApi 정보를 포함하고 있습니다.
+ * 이 엔티티는 '학습 완료(COMPLETED)' 상태인 Sign 엔티티의 정보를 저장합니다.
  *
- * 이 클래스는 데이터베이스와 연동되는 모델로서, 퀴즈 기능에서 사용되는 단어 정보를 저장, 조회 및 관리하는 데 활용됩니다.
- *
- * @author 고동현
- * @since 2025-10-12
+ * @author 백승현
+ * @since 2025-10-16
  */
 @Entity
-@Table(name = "quiz_word")
+@Table(name = "quiz_word", indexes = {
+        // Sign 엔티티와의 중복 생성을 방지하기 위해 unique 제약조건을 추가합니다.
+        @Index(name = "uk_quiz_word_sign_id", columnList = "sign_id", unique = true)
+})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuizWord {
 
-    /**
-     * 퀴즈용 단어 ID
-     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "quiz_word_id")
     private Long id;
 
     /**
-     * sign_api 단어 ID (FK)
+     * 학습 완료된 수어 단어의 ID (FK)
+     * SignApi 대신 Sign 엔티티를 직접 참조하도록 변경되었습니다.
+     * 하나의 Sign 데이터는 하나의 QuizWord만 가질 수 있으므로 OneToOne 관계를 사용합니다.
      */
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "sign_api_id")
-    private SignApi signApi;
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sign_id", nullable = false)
+    private Sign sign;
+
+    @Builder
+    public QuizWord(Sign sign) {
+        this.sign = sign;
+    }
 }

--- a/backend/src/main/java/app/signbell/backend/entity/Sign.java
+++ b/backend/src/main/java/app/signbell/backend/entity/Sign.java
@@ -8,6 +8,8 @@
 
 package app.signbell.backend.entity;
 
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -64,6 +66,9 @@ public class Sign {
      * @param newStatus 새로운 학습 상태
      */
     public void changeLearningStatus(SignStatus newStatus) {
+        if (newStatus == null) {
+            throw new BusinessException(ErrorCode.INVALID_SIGN_STATUS);
+        }
         this.learningStatus = newStatus;
     }
 

--- a/backend/src/main/java/app/signbell/backend/entity/Sign.java
+++ b/backend/src/main/java/app/signbell/backend/entity/Sign.java
@@ -1,0 +1,71 @@
+/**
+ * Sign 클래스는 수어데이터를 관리하기 위한 엔티티입니다.
+ * 각 레코드는 수어 단어, 영상 URL, 카테고리, 설명 , 모델 학습 상태를 포함합니다.
+ *
+ * @author 백승현
+ * @since 2025-10-16
+ */
+
+package app.signbell.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "sign", indexes = {
+        @Index(name = "idx_learning_status", columnList = "learningStatus")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Sign {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String title;
+
+    @Column(nullable = false, length = 1024)
+    private String url;
+
+    /**
+     * 수어 설명 (API의 signDescription)
+     * 텍스트가 길 수 있으므로 @Lob으로 지정
+     */
+    @Lob
+    @Column(columnDefinition = "TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
+    private String signDescription; // << ✨ 추가된 필드
+
+    @Column(length = 100)
+    private String categoryType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SignStatus learningStatus = SignStatus.PENDING;
+
+    @Builder
+    public Sign(String title, String url, String signDescription, String categoryType, SignStatus learningStatus) { // << ✨ 수정된 빌더
+        this.title = title;
+        this.url = url;
+        this.signDescription = signDescription; // << ✨ 추가
+        this.categoryType = categoryType;
+        // learningStatus가 null이 아닐 경우에만 전달받은 값으로 설정, null이면 기본값(PENDING) 유지
+        if (learningStatus != null) {
+            this.learningStatus = learningStatus;
+        }
+    }
+
+    /**
+     * 엔티티의 학습 상태를 변경하는 메소드입니다.
+     * @param newStatus 새로운 학습 상태
+     */
+    public void changeLearningStatus(SignStatus newStatus) {
+        this.learningStatus = newStatus;
+    }
+
+
+}

--- a/backend/src/main/java/app/signbell/backend/entity/SignApi.java
+++ b/backend/src/main/java/app/signbell/backend/entity/SignApi.java
@@ -2,54 +2,44 @@ package app.signbell.backend.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * SignApi 클래스는 한국어 수어 단어 정보를 관리하는 엔티티입니다.
- * 해당 클래스는 데이터베이스의 sign_api 테이블과 매핑되며,
- * 수어 단어의 ID, 제목, 설명, 영상 URL, 카테고리 정보를 포함하고 있습니다.
+ * 외부 API로부터 받은 원본 데이터를 가공 없이 저장하는 엔티티입니다. (Staging Table)
  *
- * 이 클래스는 수어 데이터베이스의 데이터를 저장, 조회 및 관리하는 데 사용됩니다.
- *
- *
- * @author 고동현
- * @since 2025-10-12
+ * @author 백승현
+ * @since 2025-10-16
  */
 @Entity
-@Table(name = "sign_api")
+@Table(name = "sign_api") // 테이블 이름 지정
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class SignApi {
 
-    /**
-     * 국어원 API 수어단어 ID
-     */
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "sign_api_id")
     private Long id;
 
-    /**
-     * 이름
-     */
-    @Column(nullable = false)
+    @Column(nullable = false, length = 255)
     private String title;
 
-    /**
-     * 영상 url
-     */
-    private String videoUrl;
+    @Column(nullable = false, length = 1024)
+    private String url;
 
-    /**
-     * 수어 설명
-     */
     @Lob
+    @Column(columnDefinition = "TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci")
     private String signDescription;
 
-    /**
-     * 카테고리
-     */
     @Column(length = 100)
     private String categoryType;
+
+    @Builder
+    public SignApi(String title, String url, String signDescription, String categoryType) {
+        this.title = title;
+        this.url = url;
+        this.signDescription = signDescription;
+        this.categoryType = categoryType;
+    }
 }

--- a/backend/src/main/java/app/signbell/backend/entity/SignStatus.java
+++ b/backend/src/main/java/app/signbell/backend/entity/SignStatus.java
@@ -1,0 +1,22 @@
+package app.signbell.backend.entity;
+
+/**
+ * 모델 학습 상태를 정의하는 Enum.
+ *    @author 백승현
+ *    @since 2025-10-16
+ */
+public enum SignStatus {
+    COMPLETED("완료"),
+    IN_PROGRESS("진행중"),
+    PENDING("미진행"); // 초기값
+
+    private final String koreanName;
+
+    SignStatus(String koreanName) {
+        this.koreanName = koreanName;
+    }
+
+    public String getKoreanName() {
+        return koreanName;
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/exception/ErrorCode.java
+++ b/backend/src/main/java/app/signbell/backend/exception/ErrorCode.java
@@ -65,6 +65,7 @@ public enum ErrorCode {
     WORD_LIST_EMPTY("WORD_LIST_EMPTY", "학습 가능한 단어가 없습니다.", 404),
     VIDEO_NOT_FOUND("VIDEO_NOT_FOUND", "영상을 찾을 수 없습니다.", 404),
     INVALID_WORD_ID("INVALID_WORD_ID", "유효하지 않은 단어 ID입니다.", 400),
+    INVALID_SIGN_STATUS("INVALID_SIGN_STATUS", "유효하지 않은 단어 상태입니다.", 400),
 
     // ============================================
     // 퀴즈 관련 에러 (QUIZ)

--- a/backend/src/main/java/app/signbell/backend/repository/QuizWordRepository.java
+++ b/backend/src/main/java/app/signbell/backend/repository/QuizWordRepository.java
@@ -2,6 +2,7 @@
 package app.signbell.backend.repository;
 
 import app.signbell.backend.entity.QuizWord;
+import app.signbell.backend.entity.Sign;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -18,4 +19,24 @@ import org.springframework.data.jpa.repository.JpaRepository;
  * @since 2025-10-12
  */
 public interface QuizWordRepository extends JpaRepository<QuizWord, Long> {
+
+    /**
+     * 주어진 Sign 엔티티에 해당하는 QuizWord가 존재하는지 확인합니다.
+     * @param sign 확인할 Sign 엔티티
+     * @return 존재하면 true, 그렇지 않으면 false
+     * @since 2025-10-16
+     * @author 백승현
+     */
+    boolean existsBySign(Sign sign);
+
+    /**
+     * 주어진 Sign 엔티티에 해당하는 QuizWord를 삭제합니다.
+     * @param sign 삭제할 기준이 되는 Sign 엔티티
+     * @since 2025-10-16
+     * @author 백승현
+     */
+    void deleteBySign(Sign sign);
+
+
+
 }

--- a/backend/src/main/java/app/signbell/backend/repository/SignApiRepository.java
+++ b/backend/src/main/java/app/signbell/backend/repository/SignApiRepository.java
@@ -2,20 +2,13 @@ package app.signbell.backend.repository;
 
 import app.signbell.backend.entity.SignApi;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 /**
- * SignApiRepository 인터페이스는 한국어 수어 단어 정보(SignApi 엔티티)에 대한 데이터베이스 CRUD 작업을 처리하기 위해
- * Spring Data JPA에서 제공하는 JpaRepository를 확장한 인터페이스입니다.
- *
- * 주요 기능:
- * - JpaRepository에서 제공하는 메서드를 활용하여 SignApi 데이터를 저장, 조회, 수정, 삭제할 수 있습니다.
- * - SignApi 엔티티는 데이터베이스의 sign_api 테이블과 매핑됩니다.
- * - Long 타입의 고유 ID(sign_api_id)를 기본 키로 사용합니다.
- *
- * 이 인터페이스를 사용하여 한국어 수어 데이터베이스의 데이터를 효율적으로 관리할 수 있습니다.
- *
- * @author 고동현
- * @since 2025-10-12
+ * SignApi 엔티티에 대한 데이터베이스 액세스를 처리하는 리포지토리입니다.
+ * @since 2025-10-16
+ * @author 백승현
  */
+@Repository
 public interface SignApiRepository extends JpaRepository<SignApi, Long> {
 }

--- a/backend/src/main/java/app/signbell/backend/repository/SignRepository.java
+++ b/backend/src/main/java/app/signbell/backend/repository/SignRepository.java
@@ -1,0 +1,16 @@
+package app.signbell.backend.repository;
+
+import app.signbell.backend.entity.Sign;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Sign 엔티티에 대한 데이터베이스 액세스를 처리하는 리포지토리입니다.
+ * JpaRepository를 상속받아 기본적인 CRUD 기능을 자동 생성합니다.
+ *
+ * @author 백승현
+ * @since 2025-10-16
+ */
+@Repository
+public interface SignRepository extends JpaRepository<Sign, Long> {
+}

--- a/backend/src/main/java/app/signbell/backend/repository/SignRepository.java
+++ b/backend/src/main/java/app/signbell/backend/repository/SignRepository.java
@@ -1,8 +1,13 @@
 package app.signbell.backend.repository;
 
 import app.signbell.backend.entity.Sign;
+import app.signbell.backend.repository.custom.SignRepositoryCustom;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 /**
  * Sign 엔티티에 대한 데이터베이스 액세스를 처리하는 리포지토리입니다.
@@ -12,5 +17,14 @@ import org.springframework.stereotype.Repository;
  * @since 2025-10-16
  */
 @Repository
-public interface SignRepository extends JpaRepository<Sign, Long> {
+public interface SignRepository extends JpaRepository<Sign, Long>, SignRepositoryCustom {
+    /**
+     * 특정 태그에 해당하는 모든 수어 단어를 조회합니다.
+     * @param tag 조회할 태그명
+     * @return 해당 태그를 가진 Sign 엔티티 리스트
+     */
+    Page<Sign> findByCategoryType(String categoryType, Pageable pageable);
+
+
+
 }

--- a/backend/src/main/java/app/signbell/backend/repository/custom/SignRepositoryCustom.java
+++ b/backend/src/main/java/app/signbell/backend/repository/custom/SignRepositoryCustom.java
@@ -1,0 +1,13 @@
+package app.signbell.backend.repository.custom;
+
+import java.util.List;
+
+public interface SignRepositoryCustom {
+
+    /**
+     * 저장된 모든 태그의 목록을 중복 없이 조회하고 정렬합니다.
+     * @return 태그 문자열 리스트
+     */
+    List<String> findAllTags();
+
+}

--- a/backend/src/main/java/app/signbell/backend/repository/impl/SignRepositoryImpl.java
+++ b/backend/src/main/java/app/signbell/backend/repository/impl/SignRepositoryImpl.java
@@ -1,0 +1,29 @@
+package app.signbell.backend.repository.impl;
+
+import app.signbell.backend.repository.custom.SignRepositoryCustom;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+// QSign 클래스를 static import 합니다.
+import static app.signbell.backend.entity.QSign.sign;
+/**
+ * SignRepositoryCustom의 구현체입니다. QueryDSL 쿼리를 작성합니다.
+ */
+@Repository
+@RequiredArgsConstructor
+public class SignRepositoryImpl implements SignRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<String> findAllTags() {
+        return queryFactory
+                .select(sign.categoryType).distinct() // 1. tag 컬럼을 중복 없이 선택
+                .from(sign)                 // 2. Sign 테이블에서
+                .orderBy(sign.categoryType.asc())    // 3. 태그를 오름차순으로 정렬
+                .fetch();                   // 4. 리스트로 반환
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/service/QuizWordService.java
+++ b/backend/src/main/java/app/signbell/backend/service/QuizWordService.java
@@ -1,0 +1,44 @@
+package app.signbell.backend.service;
+
+import app.signbell.backend.entity.QuizWord;
+import app.signbell.backend.entity.Sign;
+import app.signbell.backend.entity.SignStatus;
+import app.signbell.backend.repository.QuizWordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 학습 완료된 단어를 테이블에 추가하는 로직을 추가하였습니다.
+ *
+ * @author 백승현
+ * @since 2025-10-16
+ */
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class QuizWordService {
+
+    private final QuizWordRepository quizWordRepository;
+
+    @Transactional
+    public void addQuizWordIfCompleted(Sign sign) {
+        // 상태가 '완료'이고, 아직 퀴즈 단어에 없다면 추가
+        if (sign.getLearningStatus() == SignStatus.COMPLETED && !quizWordRepository.existsBySign(sign)) {
+            QuizWord quizWord = QuizWord.builder().sign(sign).build();
+            quizWordRepository.save(quizWord);
+            log.info("✅ 퀴즈 단어 추가: {}", sign.getTitle());
+        }
+    }
+
+    @Transactional
+    public void removeQuizWordIfNotCompleted(Sign sign) {
+        // 상태가 '완료'가 아니고, 퀴즈 단어에 있다면 삭제
+        if (sign.getLearningStatus() != SignStatus.COMPLETED && quizWordRepository.existsBySign(sign)) {
+            quizWordRepository.deleteBySign(sign);
+            log.info("🗑️ 퀴즈 단어 삭제: {}", sign.getTitle());
+        }
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/service/SignApiService.java
+++ b/backend/src/main/java/app/signbell/backend/service/SignApiService.java
@@ -1,0 +1,131 @@
+package app.signbell.backend.service;
+
+import app.signbell.backend.dto.response.SignApiResponse;
+import app.signbell.backend.entity.Sign;
+import app.signbell.backend.entity.SignApi;
+import app.signbell.backend.repository.SignApiRepository;
+import app.signbell.backend.repository.SignRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 외부 수어 API와 통신하여 데이터를 가져와 데이터베이스에 저장하는 서비스입니다.
+ *
+ * 최초 수어DB 구축 시에만 실행되며, 이후에는 API 호출 없이 이 로직으로 생성된 Sign 테이블의 데이터를 사용합니다.
+ *
+ * 작업 흐름은 다음과 같습니다:
+ * 1. API에서 데이터를 페이징 처리하여 모두 가져옵니다.
+ * 2. 가져온 원본 데이터를 'sign_api' 임시 테이블에 저장합니다.
+ * 3. 'sign_api' 테이블의 데이터를 가공하여 'sign' 서비스 테이블에 저장합니다.
+ *
+ * @author 백승현
+ * @since 2025-10-16
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SignApiService {
+
+    private final SignRepository signRepository;
+    private final SignApiRepository signApiRepository; // SignApi 리포지토리 주입
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Value("${api.serviceKey}")
+    private String apiServiceKey;
+
+    @Value("${api.requestUrl}")
+    private String apiRequestUrl;
+
+    @Transactional
+    public void fetchAllSignDataAndSave() {
+        // ======================================================================
+        // 1단계: API 데이터를 가져와 'sign_api' 임시 테이블에 원본 저장
+        // ======================================================================
+        if (signApiRepository.count() == 0) {
+            log.info("🚀 [1/2] API 원본 데이터 저장을 시작합니다.");
+            int pageNo = 1;
+            int numOfRows = 500;
+            boolean hasMoreData = true;
+
+            while (hasMoreData) {
+                String url = String.format("%s?serviceKey=%s&pageNo=%d&numOfRows=%d",
+                        apiRequestUrl, apiServiceKey, pageNo, numOfRows);
+                try {
+                    log.info("📡 API 호출 중... (페이지: {})", pageNo);
+                    ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+                    SignApiResponse apiResponse = objectMapper.readValue(response.getBody(), SignApiResponse.class);
+
+                    List<SignApiResponse.Response.ResponseBody.Items.Item> items = apiResponse.getResponse().getBody().getItems().getItem();
+                    if (items == null || items.isEmpty()) {
+                        hasMoreData = false;
+                        continue;
+                    }
+
+                    List<SignApi> rawDataToSave = new ArrayList<>();
+                    for (var item : items) {
+                        SignApi rawData = SignApi.builder()
+                                .title(item.getTitle())
+                                .url(item.getUrl())
+                                .signDescription(item.getSignDescription())
+                                .categoryType(item.getCategoryType())
+                                .build();
+                        rawDataToSave.add(rawData);
+                    }
+                    signApiRepository.saveAll(rawDataToSave);
+                    log.info("📄 [1/2] 페이지 {}의 원본 데이터 {}개를 'sign_api' 테이블에 저장했습니다.", pageNo, rawDataToSave.size());
+
+                    if (items.size() < numOfRows) hasMoreData = false;
+                    else pageNo++;
+                    Thread.sleep(500);
+
+                } catch (Exception e) {
+                    log.error("❗️ [1/2] API 호출 또는 원본 데이터 저장 중 오류 발생 (페이지: {})", pageNo, e);
+                    break; // 오류 발생 시 중단
+                }
+            }
+            log.info("🎉 [1/2] API 원본 데이터 저장을 완료했습니다.");
+        } else {
+            log.info("✅ [1/2] 'sign_api' 테이블에 이미 데이터가 존재하여 API 호출을 건너뜁니다.");
+        }
+
+        // ======================================================================
+        // 2단계: 'sign_api' 테이블 데이터를 'sign' 서비스 테이블로 가공 및 이전
+        // ======================================================================
+        if (signRepository.count() == 0) {
+            log.info("🚀 [2/2] 'sign_api' -> 'sign' 테이블로 데이터 이전을 시작합니다.");
+            List<SignApi> allRawData = signApiRepository.findAll();
+            List<Sign> signsToSave = new ArrayList<>();
+
+            for (SignApi rawData : allRawData) {
+                String fullTitle = rawData.getTitle().trim();
+                if (!fullTitle.isEmpty()) {
+                    Sign sign = Sign.builder()
+                            .title(fullTitle)
+                            .url(rawData.getUrl())
+                            .signDescription(rawData.getSignDescription())
+                            .categoryType(rawData.getCategoryType() != null ? rawData.getCategoryType() : "기타")
+                            .build();
+                    signsToSave.add(sign);
+                }
+            }
+
+            signRepository.saveAll(signsToSave);
+            log.info("🎉 [2/2] 'sign' 테이블로 데이터 {}개 이전을 완료했습니다.", signsToSave.size());
+        } else {
+            log.info("✅ [2/2] 'sign' 테이블에 이미 데이터가 존재하여 이전을 건너뜁니다.");
+        }
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/service/SignApiService.java
+++ b/backend/src/main/java/app/signbell/backend/service/SignApiService.java
@@ -50,9 +50,9 @@ public class SignApiService {
     private String apiRequestUrl;
 
     @Transactional
-    public void fetchAllSignDataAndSave() {
+    public long fetchAllSignDataAndSave() {
         // ======================================================================
-        // 1단계: API 데이터를 가져와 'sign_api' 임시 테이블에 원본 저장
+        // 1단계: API 데이터를 가져와 'sign_api' 테이블에 원본 저장
         // ======================================================================
         if (signApiRepository.count() == 0) {
             log.info("🚀 [1/2] API 원본 데이터 저장을 시작합니다.");
@@ -104,6 +104,7 @@ public class SignApiService {
         // ======================================================================
         // 2단계: 'sign_api' 테이블 데이터를 'sign' 서비스 테이블로 가공 및 이전
         // ======================================================================
+        long savedCount = 0; // 저장된 데이터 개수를 저장할 변수
         if (signRepository.count() == 0) {
             log.info("🚀 [2/2] 'sign_api' -> 'sign' 테이블로 데이터 이전을 시작합니다.");
             List<SignApi> allRawData = signApiRepository.findAll();
@@ -123,9 +124,11 @@ public class SignApiService {
             }
 
             signRepository.saveAll(signsToSave);
+            savedCount = signsToSave.size(); // 저장된 개수를 변수에 할당
             log.info("🎉 [2/2] 'sign' 테이블로 데이터 {}개 이전을 완료했습니다.", signsToSave.size());
         } else {
             log.info("✅ [2/2] 'sign' 테이블에 이미 데이터가 존재하여 이전을 건너뜁니다.");
         }
+        return savedCount; // 최종적으로 저장된 데이터 개수 반환
     }
 }

--- a/backend/src/main/java/app/signbell/backend/service/SignEduService.java
+++ b/backend/src/main/java/app/signbell/backend/service/SignEduService.java
@@ -1,0 +1,79 @@
+package app.signbell.backend.service;
+
+import app.signbell.backend.dto.response.signEdu.SignDetailResponseDto;
+import app.signbell.backend.dto.response.signEdu.SignSimpleResponseDto;
+import app.signbell.backend.entity.Sign;
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
+import app.signbell.backend.repository.SignRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 수어 학습 콘텐츠 조회 관련 비즈니스 로직을 처리하는 서비스입니다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true) // 조회 기능이므로 readOnly = true 설정
+public class SignEduService {
+
+    private final SignRepository signRepository;
+
+    /**
+     * 등록된 모든 카테고리(태그) 목록을 중복 없이 조회합니다.
+     * @return 카테고리 문자열 리스트
+     */
+    public List<String> findAllCategoryTypes() {
+        // SignRepositoryImpl의 findAllTags() 메서드를 호출합니다.
+        // 내부적으로 categoryType을 조회합니다.
+        return signRepository.findAllTags();
+    }
+
+    /**
+     * 모든 수어 단어 또는 특정 카테고리의 수어 단어 목록을 페이징하여 조회합니다.
+     * @param categoryType 조회할 카테고리명 (null이나 빈 문자열일 경우 전체 조회)
+     * @param pageable 페이징 정보
+     * @return SignSimpleResponseDto의 Page 객체
+     */
+    public Page<SignSimpleResponseDto> findSigns(String categoryType, Pageable pageable) {
+        Page<Sign> signsPage;
+
+        // categoryType 값이 있으면 카테고리별 조회, 없으면 전체 조회
+        if (StringUtils.hasText(categoryType)) {
+            signsPage = signRepository.findByCategoryType(categoryType, pageable);
+        } else {
+            signsPage = signRepository.findAll(pageable);
+        }
+
+        // Page<Sign>을 Page<SignSimpleResponseDto>로 변환
+        return signsPage.map(sign -> SignSimpleResponseDto.builder()
+                .signId(sign.getId())
+                .wordName(sign.getTitle())
+                .build());
+    }
+
+    /**
+     * ID를 통해 단일 수어 단어의 상세 정보를 조회합니다.
+     * @param signId 조회할 단어의 ID
+     * @return SignDetailResponseDto
+     */
+    public SignDetailResponseDto findSignById(Long signId) {
+        Sign sign = signRepository.findById(signId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.WORD_NOT_FOUND));
+
+        return SignDetailResponseDto.builder()
+                .signId(sign.getId())
+                .wordName(sign.getTitle())
+                .description(sign.getSignDescription()) // 상세 설명 필드 사용
+                .videoUrl(sign.getUrl())
+                .tag(sign.getCategoryType())
+                .build();
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/service/SignService.java
+++ b/backend/src/main/java/app/signbell/backend/service/SignService.java
@@ -2,6 +2,8 @@ package app.signbell.backend.service;
 
 import app.signbell.backend.entity.Sign;
 import app.signbell.backend.entity.SignStatus;
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
 import app.signbell.backend.repository.SignRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -24,10 +26,10 @@ public class SignService {
     private final QuizWordService quizWordService; // QuizWord 서비스 주입
 
     @Transactional
-    public void updateLearningStatus(Long signId, SignStatus newStatus) {
+    public Sign updateLearningStatus(Long signId, SignStatus newStatus) { // 반환 타입을 Sign으로 변경
         // 1. ID로 Sign 엔티티를 찾습니다.
         Sign sign = signRepository.findById(signId)
-                .orElseThrow(() -> new EntityNotFoundException("해당 Sign 데이터를 찾을 수 없습니다. id: " + signId));
+                .orElseThrow(() -> new BusinessException(ErrorCode.WORD_NOT_FOUND));
 
         // 2. 엔티티의 상태를 변경합니다.
         sign.changeLearningStatus(newStatus);
@@ -38,5 +40,7 @@ public class SignService {
         } else {
             quizWordService.removeQuizWordIfNotCompleted(sign);
         }
+
+        return sign;
     }
 }

--- a/backend/src/main/java/app/signbell/backend/service/SignService.java
+++ b/backend/src/main/java/app/signbell/backend/service/SignService.java
@@ -1,0 +1,42 @@
+package app.signbell.backend.service;
+
+import app.signbell.backend.entity.Sign;
+import app.signbell.backend.entity.SignStatus;
+import app.signbell.backend.repository.SignRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Sign 엔티티를 관리 및 조회 하는 서비스 입니다
+ *
+ * 학습 상태 변경 시 QuizWord 테이블과의 동기화를 담당합니다.
+ *
+ * @author 백승현
+ * @since 2025-10-16
+ */
+@Service
+@RequiredArgsConstructor
+public class SignService {
+
+    private final SignRepository signRepository;
+    private final QuizWordService quizWordService; // QuizWord 서비스 주입
+
+    @Transactional
+    public void updateLearningStatus(Long signId, SignStatus newStatus) {
+        // 1. ID로 Sign 엔티티를 찾습니다.
+        Sign sign = signRepository.findById(signId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 Sign 데이터를 찾을 수 없습니다. id: " + signId));
+
+        // 2. 엔티티의 상태를 변경합니다.
+        sign.changeLearningStatus(newStatus);
+
+        // 3. 상태 변경에 따라 QuizWord 테이블을 동기화합니다.
+        if (newStatus == SignStatus.COMPLETED) {
+            quizWordService.addQuizWordIfCompleted(sign);
+        } else {
+            quizWordService.removeQuizWordIfNotCompleted(sign);
+        }
+    }
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -16,11 +16,10 @@ spring:
     database-platform: org.hibernate.dialect.MariaDB106Dialect
     hibernate:
       # ddl
-      ddl-auto: create-drop
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true # SQL log
-    database: mysql
 
   # OAuth2 setting
   security:
@@ -65,3 +64,8 @@ app:
   oauth2-success-redirect-url: ${APP_OAUTH2_SUCCESS_REDIRECT_URL}
   # OAuth2 로그인 실패 프론트 리다이렉트 url
   oauth2-failure-redirect-url: ${APP_OAUTH2_FAILURE_REDIRECT_URL}
+
+# 국어원 API
+api:
+  serviceKey: "${API_SERVICE_KEY}"  # ? API_SERVICE_KEY ?? ?? ??
+  requestUrl: "${API_REQUEST_URL}" # ? API_REQUEST_URL ?? ?? ??

--- a/backend/src/test/java/app/signbell/backend/service/SignApiServiceTest.java
+++ b/backend/src/test/java/app/signbell/backend/service/SignApiServiceTest.java
@@ -1,6 +1,7 @@
 package app.signbell.backend.service;
 
 import app.signbell.backend.repository.SignRepository;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +16,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @SpringBootTest 어노테이션을 사용하여 실제 애플리케이션 컨텍스트를 로드합니다.
  */
 @SpringBootTest
+@Disabled("초기 수어 데이터 적재용 테스트로, 일반적인 테스트 환경에서는 실행하지 않습니다.")
 class SignApiServiceTest {
 
     @Autowired

--- a/backend/src/test/java/app/signbell/backend/service/SignApiServiceTest.java
+++ b/backend/src/test/java/app/signbell/backend/service/SignApiServiceTest.java
@@ -1,0 +1,44 @@
+package app.signbell.backend.service;
+
+import app.signbell.backend.repository.SignRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * SignApiService의 통합 테스트 클래스입니다.
+ * @SpringBootTest 어노테이션을 사용하여 실제 애플리케이션 컨텍스트를 로드합니다.
+ */
+@SpringBootTest
+class SignApiServiceTest {
+
+    @Autowired
+    private SignApiService signApiService;
+
+    @Autowired
+    private SignRepository signRepository;
+
+    @Test
+    @Transactional // 테스트가 끝나면 자동으로 롤백하여 DB를 원래 상태로 되돌립니다.
+    @Commit // 테스트 성공 후 DB 변경사항을 실제 커밋하고 싶을 때 사용합니다. (초기 데이터 적재용)
+    @DisplayName("외부 API에서 모든 수어 데이터를 가져와 DB에 저장한다")
+    void fetchAllSignDataAndSaveTest() {
+        // given: 테스트 실행 전 DB가 비어있는지 확인
+        long initialCount = signRepository.count();
+        assertThat(initialCount).isEqualTo(0);
+        System.out.println("✅ 초기 데이터 개수: " + initialCount);
+
+        // when: 서비스 메소드 실행
+        signApiService.fetchAllSignDataAndSave();
+
+        // then: 실행 후 DB에 데이터가 저장되었는지 확인
+        long finalCount = signRepository.count();
+        assertThat(finalCount).isGreaterThan(0L);
+        System.out.println("🎉 데이터 저장 완료! 총 저장된 데이터 개수: " + finalCount);
+    }
+}


### PR DESCRIPTION
# Pull Request
> 제목 규칙: **[타입]: 상세 내용 (#이슈번호)** 예: [Feat]: 로그인 기능 구현 (#12)

## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요. (선택된 항목은 자동 라벨링됩니다)
- [x] 기능 (Feature)
- [ ] 버그 수정 (Bugfix)
- [ ] 기능 개선 (Enhancement)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
> 이 PR이 무엇을 하는지 한눈에 파악할 수 있도록 핵심 내용을 요약합니다.

사용자 맞춤 학습을 위한 수어 단어 조회 API를 구현하고, ML 모델 연동을 위한 학습 상태 업데이트 기능을 추가합니다. 또한, 분산되어 있던 데이터 관련 API(`학습 상태 변경`, `외부 데이터 로드`)를 `SignDataController`로 통합하여 코드 구조를 개선하고 API 경로의 일관성을 확보했습니다.

---

## 관련 이슈 (Related Issue)
> 이 PR과 관련된 이슈 번호를 작성해주세요.

- Closes #36
- Closes #37
- Closes #39 


---

## 변경 사항 (Changes)
> 이 PR로 인해 변경된 점을 상세히 서술합니다.

### 1. 개인 수어 학습을 위한 조회 API 신규 구현
- **`SignEduController` 및 `SignEduService`를 신규 생성**하여 수어 학습 관련 비즈니스 로직을 처리합니다.
- **모든 카테고리 목록 조회 API** (`GET /api/sign-edu/categories`)를 구현했습니다.
- **카테고리별 단어 목록 조회 API** (`GET /api/sign-edu?category={categoryType}`)를 구현했습니다. (카테고리 미지정 시 전체 조회)
- **단일 단어 상세 정보 조회 API** (`GET /api/sign-edu/{signId}`)를 구현했습니다.
- `SignRepository`에 카테고리 기반 조회를 위한 `findByCategoryType` 메서드를 추가했습니다.

### 2. ML 연동을 위한 학습 상태 업데이트 API 구현
- ML 모델이 단어 학습 상태를 변경할 때 호출할 **학습 상태 변경 API**들을 구현했습니다.
    - **`POST /api/sign-data/{signId}/complete`** (학습 완료)
    - **`POST /api/sign-data/{signId}/start-progress`** (학습 진행중)
    - **`POST /api/sign-data/{signId}/reset`** (학습 미진행)
- 단어의 상태가 `COMPLETED`로 변경되면 `quiz_word` 테이블에 자동으로 추가되고, 다른 상태로 변경 시 자동으로 제거되도록 `SignService`와 `QuizWordService`에 동기화 로직을 추가했습니다.
- `@Transactional`을 적용하여 상태 변경과 퀴즈 단어 추가/삭제 작업의 데이터 일관성을 보장합니다.

### 3. 데이터 관리 컨트롤러 통합 리팩토링
- 기존의 **`SignStatusController`를 삭제**했습니다.
- **`SignDataController`를 신규 생성**하여 아래 기능들을 통합하고 API 경로를 `/api/sign-data`로 일원화했습니다.
    - 외부 수어 데이터 로드 및 저장 기능 (`GET /api/sign-data/getApiData`)
    - 위에서 구현한 학습 상태 업데이트 기능 (e.g., `POST /api/sign-data/{signId}/complete`)
- 외부 데이터 로드 API의 응답 형식을 저장된 데이터 개수를 포함하는 `SignDataLoadResponseDto`로 변경하여 작업 결과를 명확히 알 수 있도록 개선했습니다.
---

## 스크린샷 (Screenshots) (Optional)
> UI/UX 변경 사항이 있다면, 변경 전후 스크린샷을 첨부해주세요.

백엔드 API 변경 사항으로 해당 사항 없습니다.

---

## 테스트 방법 (Test Steps)
> 리뷰어가 이 변경 사항을 로컬에서 직접 검증할 수 있도록 구체적인 절차를 작성해주세요.

1.  **(사전 준비: 데이터 로드)** Postman으로 `GET http://localhost:8080/api/sign-data/getApiData` API를 호출하여 테스트에 필요한 기본 수어 데이터를 DB에 저장합니다. `SignDataLoadResponseDto` 형식으로 저장된 개수가 반환되는지 확인합니다. (최초 실행 시 약 2-3분 소요)

2.  **(카테고리 목록 조회)** `GET http://localhost:8080/api/sign-edu/categories` API를 호출하여 DB에 저장된 모든 카테고리 목록이 정상적으로 조회되는지 확인합니다.

3.  **(카테고리별 단어 목록 조회)** 위에서 조회된 카테고리 중 하나를 선택하여 `GET http://localhost:8080/api/sign-edu?category=카테고리명` API를 호출합니다. 해당 카테고리에 속한 단어 목록이 페이징 처리되어 정상적으로 반환되는지 확인합니다.

4.  **(단어 상세 조회)** 위 목록에서 특정 단어의 `signId`를 확인하고, `GET http://localhost:8080/api/sign-edu/{signId}` API를 호출하여 해당 단어의 상세 정보가 정확히 반환되는지 확인합니다.

5.  **(학습 상태 변경 및 퀴즈 연동 확인)**
    * Postman으로 `POST http://localhost:8080/api/sign-data/{signId}/complete` API를 호출합니다.
    * `sign` 테이블에서 해당 `signId`를 가진 데이터의 `learning_status`가 `COMPLETED`로 변경되었는지 DB에서 확인합니다.
    * `quiz_word` 테이블에 해당 `signId`를 가진 데이터가 새로 추가되었는지 DB에서 확인합니다.

---

## 셀프 체크리스트 (Self-Checklist)
> 리뷰 요청 전, 아래 항목을 확인해주세요.
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [ ] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)
> 리뷰어가 특별히 더 신경 써서 봐야 할 부분이나 참고사항을 작성해주세요.
> (예: 성능 최적화 부분 집중 검토 필요, API 스펙 변경 사항 확인 요청 등)

기존 application-dev.yml 파일에 국어원 API 환경설정이 추가되었습니다.
디스코드에 공유된 최신 .env 파일을 적용해야 온전히 작동합니다. 