### PR TITLE
[Bugfix]: WebSocket 서비스 간 순환 참조 해결  (#42)

### DIFF
--- a/backend/src/main/java/app/signbell/backend/service/GameRoomLeaveService.java
+++ b/backend/src/main/java/app/signbell/backend/service/GameRoomLeaveService.java
@@ -10,6 +10,8 @@ import app.signbell.backend.repository.GameParticipantRepository;
 import app.signbell.backend.repository.GameRoomRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,13 +33,23 @@ import java.util.List;
  * @since 2025-10-16
  */
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class GameRoomLeaveService {
 
     private final GameParticipantRepository participantRepository;
     private final GameRoomRepository gameRoomRepository;
     private final WebSocketSessionService sessionService;
+
+
+    public GameRoomLeaveService(
+            GameParticipantRepository participantRepository,
+            GameRoomRepository gameRoomRepository,
+            @Lazy WebSocketSessionService sessionService // <- 여기에 @Lazy 추가
+    ) {
+        this.participantRepository = participantRepository;
+        this.gameRoomRepository = gameRoomRepository;
+        this.sessionService = sessionService;
+    }
 
     /**
      * 사용자 ID로 현재 참여 중인 게임방에서 퇴장 처리


### PR DESCRIPTION
# [Bugfix]: WebSocket 서비스 간 순환 참조 해결 (#42)

## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요. (선택된 항목은 자동 라벨링됩니다)
- [ ] 기능 (Feature)
- [x] 버그 수정 (Bugfix)
- [ ] 기능 개선 (Enhancement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
`WebSocketSessionService`와 `GameRoomLeaveService` 간의 순환 참조로 인해 애플리케이션 실행이 실패하는 문제를 해결했습니다. `GameRoomLeaveService`에서 `@Lazy` 어노테이션을 사용하여 의존성 주입 시점을 지연시켜 순환 고리를 끊었습니다.

---

## 관련 이슈 (Related Issue)
- Closes #42

---

## 변경 사항 (Changes)
- **`GameRoomLeaveService.java`**
  - `@RequiredArgsConstructor` 어노테이션을 제거하고 명시적인 생성자로 변경했습니다.
  - 생성자의 `WebSocketSessionService` 파라미터에 `@Lazy` 어노테이션을 추가하여, 해당 Bean의 초기화를 실제 사용 시점까지 지연시켰습니다.
  - 위 변경을 통해 두 서비스 간의 순환 참조 문제가 해결되어 애플리케이션이 정상적으로 구동됩니다.

---

## 테스트 방법 (Test Steps)
1. `dev` 브랜치에서 최신 코드를 `pull` 받습니다.
2. 로컬 환경에서 Spring Boot 애플리케이션을 실행합니다 (`bootRun`).
3. 기존에 발생하던 `UnsatisfiedDependencyException` (순환 참조) 오류 없이 애플리케이션이 정상적으로 시작되는지 확인합니다.

---

## 셀프 체크리스트 (Self-Checklist)
> 리뷰 요청 전, 아래 항목을 확인해주세요.
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [ ] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)
급한 실행 오류를 해결하기 위해 가장 효과적인 `@Lazy`를 적용했습니다. 구조적으로 더 개선할 부분이 있을지 함께 고민해주시면 감사하겠습니다!