### PR TITLE
[Feat]: 게임방 참가자 준비 상태 변경 기능 구현 (#45)

### DIFF
--- a/backend/src/main/java/app/signbell/backend/controller/gameRoom/GameRoomReadyController.java
+++ b/backend/src/main/java/app/signbell/backend/controller/gameRoom/GameRoomReadyController.java
@@ -1,0 +1,132 @@
+package app.signbell.backend.controller.gameRoom;
+
+import app.signbell.backend.dto.common.ApiResponse;
+import app.signbell.backend.dto.request.ReadyStatusRequest;
+import app.signbell.backend.dto.response.ReadyStatusResponse;
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
+import app.signbell.backend.exception.dto.ErrorResponse;
+import app.signbell.backend.service.GameRoomReadyService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.stereotype.Controller;
+
+import java.time.LocalDateTime;
+
+/**
+ * GameRoomReadyController 클래스는 WebSocket을 통한 게임방 참가자의 준비 상태 변경 요청을 처리하는 컨트롤러입니다.
+ *
+ * 주요 역할:
+ * 1. 클라이언트로부터 참가자 준비 상태 변경 요청을 수신합니다.
+ * 2. JWT 기반 사용자 인증을 통해 요청자를 식별합니다.
+ * 3. GameRoomReadyService를 호출하여 비즈니스 로직을 처리합니다.
+ * 4. 변경된 준비 상태를 방의 모든 참가자에게 브로드캐스트합니다.
+ * 5. 에러 발생 시 해당 사용자에게만 에러 메시지를 전송합니다.
+ *
+ * STOMP 프로토콜을 사용하며, 다음과 같은 메시지 경로를 처리합니다:
+ * - 수신: /app/room/{gameRoomId}/participant/ready
+ * - 브로드캐스트: /topic/room/{gameRoomId}/participant
+ * - 에러 응답: /user/queue/errors
+ *
+ * @author 강관주
+ * @since 2025-10-17
+ */
+@Controller
+@RequiredArgsConstructor
+@Slf4j
+public class GameRoomReadyController {
+
+    private final GameRoomReadyService gameRoomReadyService;
+    private final SimpMessagingTemplate messagingTemplate;
+
+    /**
+     * 게임방 참가자의 준비 상태 변경 요청을 처리하는 메서드.
+     *
+     * 클라이언트가 /app/room/{gameRoomId}/participant/ready 경로로 메시지를 전송하면
+     * 이 메서드가 호출되어 참가자의 준비 상태를 변경하고 결과를 브로드캐스트합니다.
+     *
+     * 처리 흐름:
+     * 1. JWT 토큰에서 사용자 ID를 추출합니다.
+     * 2. GameRoomReadyService를 호출하여 준비 상태를 변경합니다.
+     * 3. 변경된 상태를 방의 모든 참가자에게 브로드캐스트합니다.
+     * 4. 에러 발생 시 해당 사용자에게만 에러 메시지를 전송합니다.
+     *
+     * @param gameRoomId 준비 상태를 변경할 게임방의 ID (STOMP 목적지 경로에서 추출)
+     * @param subject JWT 토큰에서 추출한 사용자 ID (Principal)
+     * @param request 준비 상태 변경 요청 정보 (isReady: true/false)
+     */
+    @MessageMapping("/room/{gameRoomId}/participant/ready")
+    public void updateReadyStatus(
+            @DestinationVariable Long gameRoomId,
+            @AuthenticationPrincipal String subject,
+            @Payload ReadyStatusRequest request
+    ) {
+        try {
+            // 준비 상태 변경 요청 수신 로그
+            log.info("Ready status update request from user={} for room={}", subject, gameRoomId);
+
+            // JWT subject(String)를 Long 타입의 userId로 변환
+            Long userId = Long.valueOf(subject);
+
+            // 서비스 호출: 준비 상태 변경 처리 및 전체 참가자의 준비 상태 계산
+            ReadyStatusResponse response = gameRoomReadyService.updateReadyStatus(gameRoomId, userId, request.isReady());
+
+            // 방의 모든 참가자에게 준비 상태 변경 알림 브로드캐스트
+            // - 누가 준비 상태를 변경했는지
+            // - 현재 모든 참가자가 준비 완료되었는지 (allReady)
+            messagingTemplate.convertAndSend(
+                    "/topic/room/" + gameRoomId + "/participant",
+                    ApiResponse.success("참가자의 준비 상태가 변경되었습니다.", response)
+            );
+
+
+        } catch (BusinessException e) {
+            log.warn("방 입장 중 비즈니스 예외 발생 - errorCode: {}, message: {}",
+                    e.getErrorCode().getCode(), e.getMessage());
+            sendError(subject, e.getErrorCode());
+
+        } catch (NumberFormatException e) {
+            log.error("사용자 ID 파싱 실패 - subject: {}", subject);
+            sendError(subject, ErrorCode.INVALID_INPUT);
+
+        } catch (Exception e) {
+            log.error("방 입장 처리 중 예상치 못한 오류 발생", e);
+            sendError(subject, ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+
+
+    /**
+     * 에러 메시지를 특정 사용자에게 전송하는 메서드.
+     *
+     * 방 입장 처리 중 발생한 에러를 해당 사용자에게만 전송합니다.
+     * ErrorCode를 기반으로 ErrorResponse 객체를 생성하여 전송합니다.
+     *
+     * @param userId 에러 메시지를 받을 사용자의 ID
+     * @param errorCode 발생한 에러의 ErrorCode
+     */
+    private void sendError(String userId, ErrorCode errorCode) {
+        ErrorResponse error = ErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(errorCode.getStatus())
+                .error(errorCode.getCode())
+                .detail(errorCode.getMessage())
+                .path("/app/room/participant/ready")
+                .build();
+
+        messagingTemplate.convertAndSendToUser(
+                userId,
+                "/queue/errors",
+                error
+        );
+
+        log.warn("Error sent to user {} - code: {}, message: {}",
+                userId, errorCode.getCode(), errorCode.getMessage());
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/dto/request/ReadyStatusRequest.java
+++ b/backend/src/main/java/app/signbell/backend/dto/request/ReadyStatusRequest.java
@@ -1,0 +1,21 @@
+package app.signbell.backend.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * ReadyStatusRequest 클래스는 특정 사용자의 '준비 상태'를 전달하기 위한 DTO입니다.
+ *
+ * 해당 클래스는 클라이언트가 준비 상태를 서버에 전달하거나 업데이트를 요청할 때 사용됩니다.
+ * 주로 게임 방에서 특정 사용자의 준비 여부를 확인하거나 변경하는 데 활용됩니다.
+ *
+ * @author 강관주
+ * @since 2025-10-17
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReadyStatusRequest {
+    private boolean isReady;
+}

--- a/backend/src/main/java/app/signbell/backend/dto/response/ReadyStatusResponse.java
+++ b/backend/src/main/java/app/signbell/backend/dto/response/ReadyStatusResponse.java
@@ -1,0 +1,26 @@
+package app.signbell.backend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * ReadyStatusResponse 클래스는 게임 내 참가자의 준비 상태에 대한 정보를 담고 있는 객체를 나타냅니다.
+ *
+ * 주요 사용처:
+ * - 클라이언트-서버 간 통신에서 참가자의 준비 상태 변경 정보를 전달
+ * - 실시간으로 참가자의 준비 상태를 UI 및 게임 로직에 반영
+ *
+ * @author 강관주
+ * @since 2025-10-17
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class ReadyStatusResponse {
+    private String eventType; // "PARTICIPANT_READY_UPDATED"
+    private Long userId;
+    private String nickname;
+    private boolean isReady;
+    private boolean allReady;
+}

--- a/backend/src/main/java/app/signbell/backend/entity/GameParticipant.java
+++ b/backend/src/main/java/app/signbell/backend/entity/GameParticipant.java
@@ -90,4 +90,11 @@ public class GameParticipant {
     public void syncRound() {
         this.currentRound = this.gameRoom.getCurrentRound();
     }
+
+    /**
+     * 참여자의 준비 상태를 변경시킵니다.
+     */
+    public void changeReadyStatus(boolean isReady) {
+        this.isReady = isReady;
+    }
 }

--- a/backend/src/main/java/app/signbell/backend/exception/ErrorCode.java
+++ b/backend/src/main/java/app/signbell/backend/exception/ErrorCode.java
@@ -57,6 +57,7 @@ public enum ErrorCode {
     CAMERA_PERMISSION_REQUIRED("CAMERA_PERMISSION_REQUIRED", "카메라 권한이 필요합니다.", 403),
     PARTICIPANT_NOT_IN_ROOM("PARTICIPANT_NOT_IN_ROOM", "방에 참여하지 않은 사용자입니다.", 400),
     PARTICIPANT_NOT_READY("PARTICIPANT_NOT_READY", "참가자가 준비되지 않았습니다.", 400),
+    NOT_ALLOWED_READY_FOR_HOST("NOT_ALLOWED_READY_FOR_HOST", "방장은 준비 상태를 변경할 수 없습니다.", 403),
 
     // ============================================
     // 단어/학습 관련 에러 (WORD)

--- a/backend/src/main/java/app/signbell/backend/service/GameRoomReadyService.java
+++ b/backend/src/main/java/app/signbell/backend/service/GameRoomReadyService.java
@@ -1,0 +1,112 @@
+package app.signbell.backend.service;
+
+import app.signbell.backend.dto.response.ReadyStatusResponse;
+import app.signbell.backend.entity.GameParticipant;
+import app.signbell.backend.entity.GameRoom;
+import app.signbell.backend.entity.GameRoomStatus;
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
+import app.signbell.backend.repository.GameParticipantRepository;
+import app.signbell.backend.repository.GameRoomRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * GameRoomReadyService 클래스는 사용자와 게임방의 준비 상태를 관리하는 역할을 수행합니다.
+ *
+ * 주요 기능:
+ * - 특정 게임 방에서 사용자의 준비 상태를 업데이트
+ * - 업데이트된 준비 상태를 바탕으로 전체 참가자의 준비 여부 확인
+ * - 요청 결과에 대한 응답 생성 및 반환
+ *
+ * 이 서비스는 게임 진행 상태, 방의 존재 여부, 참가자의 유효성 등을 검증하며,
+ * 적절하지 않은 경우 예외를 발생시킵니다.
+ *
+ * 종속성:
+ * - GameRoomRepository: 게임방 데이터 처리
+ * - GameParticipantRepository: 게임 참가자 데이터 처리
+ *
+ * @author 강관주
+ * @since 2025-10-17
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class GameRoomReadyService {
+
+    private final GameRoomRepository gameRoomRepository;
+    private final GameParticipantRepository gameParticipantRepository;
+
+    /**
+     * 사용자가 특정 게임 방에서 준비 상태를 업데이트하는 메서드.
+     * 준비 상태를 업데이트한 후, 전체 참가자의 준비 상태를 계산하여 응답 객체를 반환합니다.
+     *
+     * @param roomId 준비 상태를 업데이트할 게임 방의 ID
+     * @param userId 준비 상태를 변경할 사용자의 ID
+     * @param isReady 변경할 준비 상태 (true: 준비 완료, false: 준비 취소)
+     * @return 준비 상태 변경 결과를 포함한 ReadyStatusResponse 객체
+     * @throws BusinessException 게임 방이 존재하지 않거나, 게임 상태가 유효하지 않거나,
+     *                           참가자가 존재하지 않거나, 방장이 준비 상태를 변경하려는 경우 발생
+     */
+    @Transactional
+    public ReadyStatusResponse updateReadyStatus(Long roomId, Long userId, boolean isReady) {
+        log.info("User {} attempting to update ready status in room {}", userId, roomId);
+
+        // 1. 방 존재 및 상태 확인 (빠른 실패 전략)
+        GameRoom room = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> {
+                    log.error("게임 방을 찾을 수 없습니다. gameRoomId={}", roomId);
+                    return new BusinessException(ErrorCode.ROOM_NOT_FOUND);
+                });
+
+        // 2. 방 상태 검증
+        if (room.getStatus() == GameRoomStatus.IN_PROGRESS) {
+            log.warn("이미 진행 중인 방입니다. gameRoomId={}", roomId);
+            throw new BusinessException(ErrorCode.ROOM_ALREADY_STARTED);
+        }
+        if (room.getStatus() == GameRoomStatus.FINISHED) {
+            log.warn("이미 종료된 방입니다. gameRoomId={}", roomId);
+            throw new BusinessException(ErrorCode.ROOM_ALREADY_FINISHED);
+        }
+
+        // 3. 참가자 조회 (User 정보 포함, JOIN FETCH로 N+1 방지)
+        GameParticipant gameParticipant = gameParticipantRepository
+                .findByGameRoom_IdAndParticipant_Id(roomId, userId)
+                .orElseThrow(() -> {
+                    log.error("참가자를 찾을 수 없습니다. userId={}, roomId={}", userId, roomId);
+                    return new BusinessException(ErrorCode.PARTICIPANT_NOT_FOUND);
+                });
+
+        // 4. 방장은 항상 준비 상태이므로 변경 불가
+        if (gameParticipant.isHost()) {
+            throw new BusinessException(ErrorCode.NOT_ALLOWED_READY_FOR_HOST);
+        }
+
+        // 5. 준비 상태 변경 (save() 불필요 - Dirty Checking 자동 처리)
+        gameParticipant.changeReadyStatus(isReady);
+        log.info("User {} ready status changed to {} in room {}", userId, isReady, roomId);
+
+        // 6. 전체 참가자의 준비 상태 계산
+        List<GameParticipant> allParticipants = gameParticipantRepository
+                .findByGameRoom_Id(roomId);
+
+        boolean allReady = allParticipants.stream()
+                .allMatch(GameParticipant::isReady);
+
+        log.info("Room {} ready status - allReady: {}, participants: {}",
+                roomId, allReady, allParticipants.size());
+
+        // 7. 응답 생성 (이미 fetch된 User 정보 활용)
+        return ReadyStatusResponse.builder()
+                .eventType("PARTICIPANT_READY_UPDATED")
+                .userId(userId)
+                .nickname(gameParticipant.getParticipant().getNickname())
+                .isReady(isReady)
+                .allReady(allReady)
+                .build();
+    }
+}


### PR DESCRIPTION

## PR 유형 (Type of PR)
- [x] 기능 (Feature)
- [ ] 버그 수정 (Bugfix)
- [ ] 기능 개선 (Enhancement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
실시간 퀴즈 게임에서 참가자들이 준비 상태를 변경하고, 모든 참가자가 준비 완료되면 방장이 게임을 시작할 수 있도록 하는 WebSocket 기반 준비 상태 관리 기능을 구현했습니다.

---

## 관련 이슈 (Related Issue)
- Closes #45

---

## 변경 사항 (Changes)

### 1. DTO 추가
- `ReadyStatusRequest`: 클라이언트의 준비 상태 변경 요청을 받는 DTO
- `ReadyStatusResponse`: 준비 상태 변경 결과를 반환하는 DTO
  - `eventType`, `userId`, `nickname`, `isReady`, `allReady` 필드 포함

### 2. 엔티티 수정
- `GameParticipant`에 `changeReadyStatus()` 메서드 추가
  - 참가자의 준비 상태를 변경하는 비즈니스 로직 캡슐화

### 3. 에러 코드 추가
- `NOT_ALLOWED_READY_FOR_HOST`: 방장이 준비 상태를 변경하려 할 때 발생하는 에러 코드 (403)

### 4. 서비스 구현
- `GameRoomReadyService` 추가
  - 방 상태 검증 (WAITING 상태만 준비 상태 변경 가능)
  - 참가자 준비 상태 변경 (Dirty Checking 활용)
  - 전체 참가자의 준비 상태 계산 (`allReady`)
  - 방장의 준비 상태 변경 차단

### 5. 컨트롤러 구현
- `GameRoomReadyController` 추가
  - WebSocket 메시지 수신: `/app/room/{gameRoomId}/participant/ready`
  - 브로드캐스트: `/topic/room/{gameRoomId}/participant`
  - 에러 전송: `/user/queue/errors`
  - JWT 기반 사용자 인증 및 예외 처리

### 6. 성능 최적화
- Repository의 JOIN FETCH를 활용하여 N+1 문제 방지
- Dirty Checking을 활용하여 불필요한 save() 호출 제거

---

## 테스트 방법 (Test Steps)

### 1. WebSocket 연결 및 구독
```javascript
// 방 참가자 이벤트 구독
stompClient.subscribe(`/topic/room/${gameRoomId}/participant`, (message) => {
  console.log('Ready status updated:', JSON.parse(message.body));
});

// 에러 구독
stompClient.subscribe('/user/queue/errors', (message) => {
  console.error('Error:', JSON.parse(message.body));
});
```

### 2. 준비 상태 변경 요청
```javascript
// 준비 완료
stompClient.send(
  `/app/room/${gameRoomId}/participant/ready`,
  {},
  JSON.stringify({ isReady: true })
);

// 준비 해제
stompClient.send(
  `/app/room/${gameRoomId}/participant/ready`,
  {},
  JSON.stringify({ isReady: false })
);
```

### 3. 예상 응답
```json
{
  "success": true,
  "message": "참가자의 준비 상태가 변경되었습니다.",
  "data": {
    "eventType": "PARTICIPANT_READY_UPDATED",
    "userId": 123,
    "nickname": "판주",
    "isReady": true,
    "allReady": false
  }
}
```


---

## 셀프 체크리스트 (Self-Checklist)
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [ ] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [ ] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)

### 주요 리뷰 포인트
1. **성능 최적화**: JOIN FETCH와 Dirty Checking을 통한 쿼리 최적화가 적절한지 확인 부탁드립니다.
2. **에러 처리**: 방장이 준비 상태를 변경하려 할 때의 에러 코드(`NOT_ALLOWED_READY_FOR_HOST`)가 적절한지 검토 부탁드립니다.
3. **비즈니스 로직**: `allReady` 계산 로직이 모든 참가자(방장 포함)의 준비 상태를 올바르게 반영하는지 확인 부탁드립니다.
