### PR TITLE
[Feat]: 게임 방 조회 기능 개선 및 상세 조회 API 추가 (#50, #51)

### DIFF
--- a/backend/src/main/java/app/signbell/backend/controller/gameRoom/RoomListController.java
+++ b/backend/src/main/java/app/signbell/backend/controller/gameRoom/RoomListController.java
@@ -1,6 +1,7 @@
 package app.signbell.backend.controller.gameRoom;
 
 import app.signbell.backend.dto.common.ApiResponse;
+import app.signbell.backend.dto.response.RoomDetailResponse;
 import app.signbell.backend.dto.response.RoomListSliceResponse;
 import app.signbell.backend.exception.BusinessException;
 import app.signbell.backend.exception.ErrorCode;
@@ -9,10 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * RoomListController는 퀴즈 방 리스트를 관리하는 REST API의 컨트롤러 클래스입니다.
@@ -20,11 +18,13 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * 주요 기능:
  * - 사용자 인증 정보를 기반으로 퀴즈 방 목록을 페이징 처리하여 제공
+ * - 특정 방의 상세 정보 조회
  * - 인증 주체(subject)를 Long 타입 사용자 ID로 변환
  * - 요청 성공 및 실패에 따른 로깅 처리
  *
  * 요청 처리:
  * - GET 요청: "/api/quiz/rooms" 엔드포인트에 대해 방 목록을 조회
+ * - GET 요청: "/api/quiz/rooms/{roomId}" 엔드포인트에 대해 특정 방 상세 정보를 조회
  * - 기본 페이징 매개변수: page=0, size=10
  *
  * 의존성:
@@ -78,6 +78,38 @@ public class RoomListController {
             // 이는 보통 인증 시스템 설정 문제이거나, 예상치 못한 상황
             log.error("인증된 사용자 ID(subject)를 Long으로 변환하는 데 실패했습니다: {}", subject, e);
             throw new BusinessException(ErrorCode.UNAUTHORIZED); // 인증/변환 오류
+        }
+    }
+
+    /**
+     * 특정 퀴즈 방의 상세 정보를 조회하여 클라이언트에게 응답합니다.
+     *
+     * @param roomId 조회할 방의 ID
+     * @param subject 인증된 사용자의 ID를 나타내는 문자열 (JWT 토큰에서 추출된 주체)
+     * @return 퀴즈 방 상세 정보를 포함하는 응답 객체
+     * @throws BusinessException 인증 주체(subject)가 Long 타입으로 변환되지 않을 경우 발생하며,
+     *         이는 인증 오류로 간주됩니다.
+     */
+    @GetMapping("/{roomId}")
+    public ResponseEntity<ApiResponse<RoomDetailResponse>> getRoomDetail(
+            @PathVariable Long roomId,
+            @AuthenticationPrincipal String subject) {
+
+        try {
+            Long userId = Long.valueOf(subject);
+
+            log.info("방 상세 정보 조회 요청. userId={}, roomId={}", userId, roomId);
+
+            RoomDetailResponse response = roomListService.getRoomDetail(roomId);
+
+            ApiResponse<RoomDetailResponse> apiResponse =
+                    ApiResponse.success("퀴즈 방 상세 정보를 조회했습니다.", response);
+
+            return ResponseEntity.ok(apiResponse);
+
+        } catch (NumberFormatException e) {
+            log.error("인증된 사용자 ID(subject)를 Long으로 변환하는 데 실패했습니다: {}", subject, e);
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
         }
     }
 }

--- a/backend/src/main/java/app/signbell/backend/dto/response/RoomDetailResponse.java
+++ b/backend/src/main/java/app/signbell/backend/dto/response/RoomDetailResponse.java
@@ -1,0 +1,38 @@
+package app.signbell.backend.dto.response;
+
+import app.signbell.backend.entity.GameRoom;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * RoomDetailResponse 클래스는 특정 게임 방의 상세 정보를 담고 있는 응답 객체입니다.
+ *
+ * 이 클래스는 게임 방 ID, 게임 제목, 현재 참여자 수, 최대 참여자 수, 상태 정보를 포함합니다.
+ *
+ * 정적 팩토리 메서드인 from(GameRoom gameRoom)을 통해 GameRoom 엔티티로부터
+ * RoomDetailResponse 객체를 간단하게 생성할 수 있습니다.
+ *
+ * @author 강관주
+ * @since 2025-10-19
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class RoomDetailResponse {
+    private Long gameRoomId;
+    private String gameTitle;
+    private Integer currentParticipants;
+    private Integer maxParticipants;
+    private String status;
+
+    public static RoomDetailResponse from(GameRoom gameRoom) {
+        return RoomDetailResponse.builder()
+                .gameRoomId(gameRoom.getId())
+                .gameTitle(gameRoom.getGameTitle())
+                .currentParticipants(gameRoom.getCurrentParticipants())
+                .maxParticipants(gameRoom.getMaxParticipants())
+                .status(gameRoom.getStatus().name())
+                .build();
+    }
+}

--- a/backend/src/main/java/app/signbell/backend/repository/custom/GameRoomRepositoryCustom.java
+++ b/backend/src/main/java/app/signbell/backend/repository/custom/GameRoomRepositoryCustom.java
@@ -13,10 +13,10 @@ import org.springframework.data.domain.Slice;
 public interface GameRoomRepositoryCustom {
 
     /**
-     * WAITING 상태의 퀴즈 방 목록을 조회합니다. (무한 스크롤)
+     * WAITING 또는 IN_PROGRESS 상태의 퀴즈 방 목록을 조회합니다. (무한 스크롤)
      *
      * @param pageable 페이징 정보
      * @return 방 목록 Slice
      */
-    Slice<GameRoom> findWaitingRooms(Pageable pageable);
+    Slice<GameRoom> findActiveRooms(Pageable pageable);
 }

--- a/backend/src/main/java/app/signbell/backend/repository/impl/GameRoomRepositoryImpl.java
+++ b/backend/src/main/java/app/signbell/backend/repository/impl/GameRoomRepositoryImpl.java
@@ -31,7 +31,7 @@ public class GameRoomRepositoryImpl implements GameRoomRepositoryCustom {
     private final JPAQueryFactory queryFactory;
 
     /**
-     * WAITING 상태의 게임방 목록을 무한 스크롤 방식으로 조회합니다.
+     * WAITING 또는 IN_PROGRESS 상태의 게임방 목록을 무한 스크롤 방식으로 조회합니다.
      * 조회 결과는 요청된 페이징 정보에 따라 정렬 및 개수 제한이 적용됩니다.
      *
      * @param pageable 페이징 정보를 포함하는 객체
@@ -40,7 +40,7 @@ public class GameRoomRepositoryImpl implements GameRoomRepositoryCustom {
      *         (다음 페이지 존재 여부 포함)
      */
     @Override
-    public Slice<GameRoom> findWaitingRooms(Pageable pageable) {
+    public Slice<GameRoom> findActiveRooms(Pageable pageable) {
         /*
             무한 스크롤 구현 로직:
             1. 요청한 size보다 1개 더 조회 (size + 1)
@@ -57,7 +57,7 @@ public class GameRoomRepositoryImpl implements GameRoomRepositoryCustom {
         List<GameRoom> roomList = queryFactory
                 .selectFrom(gameRoom)
                 .leftJoin(gameRoom.host).fetchJoin() // N+1 방지
-                .where(gameRoom.status.eq(GameRoomStatus.WAITING))
+                .where(gameRoom.status.in(GameRoomStatus.WAITING, GameRoomStatus.IN_PROGRESS))
                 .orderBy(gameRoom.createdAt.desc())
                 .offset(pageable.getOffset())           // 건너뛸 개수
                 .limit(pageable.getPageSize() + 1)      // 조회할 개수 + 1

--- a/backend/src/main/java/app/signbell/backend/service/RoomListService.java
+++ b/backend/src/main/java/app/signbell/backend/service/RoomListService.java
@@ -21,15 +21,15 @@ import java.util.stream.Collectors;
 
 /**
  * RoomListService는 게임 방 리스트를 조회하는 기능을 제공합니다.
- * 이 서비스를 통해 대기 상태의 게임 방 목록을 페이징 처리하여 가져올 수 있습니다.
+ * 이 서비스를 통해 활성 상태(WAITING, IN_PROGRESS)의 게임 방 목록을 페이징 처리하여 가져올 수 있습니다.
  *
  * 주요 기능:
- * - 게임 방 목록 조회
+ * - 게임 방 목록 조회 (WAITING, IN_PROGRESS 상태만)
  * - 특정 게임 방 상세 정보 조회
  * - 페이지 크기 유효성 검사 및 기본값 설정
  *
  * 의존성:
- * - GameRoomRepository: 대기 상태의 게임 방 정보를 데이터베이스에서 조회하기 위한 Repository
+ * - GameRoomRepository: 활성 상태의 게임 방 정보를 데이터베이스에서 조회하기 위한 Repository
  *
  * 트랜잭션:
  * - 읽기 전용(readOnly = true) 트랜잭션 설정
@@ -46,12 +46,12 @@ public class RoomListService {
     private final GameRoomRepository gameRoomRepository;
 
     /**
-     * 주어진 페이지 번호와 페이지 크기를 기반으로 대기 상태의 게임 방 목록을 조회합니다.
-     * 조회된 결과는 페이징된 형태의 응답으로 반환됩니다.
+     * 주어진 페이지 번호와 페이지 크기를 기반으로 활성 상태의 게임 방 목록을 조회합니다.
+     * WAITING 또는 IN_PROGRESS 상태의 방만 조회되며, 조회된 결과는 페이징된 형태의 응답으로 반환됩니다.
      *
      * @param page 조회할 페이지 번호 (0부터 시작)
      * @param size 한 페이지에 조회할 방의 개수 (1 이상 100 이하)
-     * @return 대기 상태의 게임 방 목록과 다음 페이지 존재 여부 정보를 포함한 응답 객체
+     * @return 활성 상태의 게임 방 목록과 다음 페이지 존재 여부 정보를 포함한 응답 객체
      */
     public RoomListSliceResponse getRoomList(int page, int size) {
 
@@ -64,8 +64,8 @@ public class RoomListService {
         // Pageable 생성
         Pageable pageable = PageRequest.of(page, size);
 
-        // WAITING 상태의 방 목록 조회
-        Slice<GameRoom> roomSlice = gameRoomRepository.findWaitingRooms(pageable);
+        // WAITING 또는 IN_PROGRESS 상태의 방 목록 조회
+        Slice<GameRoom> roomSlice = gameRoomRepository.findActiveRooms(pageable);
 
         // Entity -> DTO 변환
         List<RoomListResponse> rooms = roomSlice.getContent()

--- a/backend/src/main/java/app/signbell/backend/service/RoomListService.java
+++ b/backend/src/main/java/app/signbell/backend/service/RoomListService.java
@@ -1,8 +1,12 @@
 package app.signbell.backend.service;
 
+import app.signbell.backend.dto.response.RoomDetailResponse;
 import app.signbell.backend.dto.response.RoomListResponse;
 import app.signbell.backend.dto.response.RoomListSliceResponse;
 import app.signbell.backend.entity.GameRoom;
+import app.signbell.backend.entity.GameRoomStatus;
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
 import app.signbell.backend.repository.GameRoomRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,6 +25,7 @@ import java.util.stream.Collectors;
  *
  * 주요 기능:
  * - 게임 방 목록 조회
+ * - 특정 게임 방 상세 정보 조회
  * - 페이지 크기 유효성 검사 및 기본값 설정
  *
  * 의존성:
@@ -73,5 +78,32 @@ public class RoomListService {
 
         // Slice 응답 생성
         return RoomListSliceResponse.from(rooms, roomSlice.hasNext());
+    }
+
+    /**
+     * 특정 게임 방의 상세 정보를 조회합니다.
+     * FINISHED 상태의 방은 조회되지 않습니다.
+     *
+     * @param roomId 조회할 방의 ID
+     * @return 게임 방의 상세 정보를 담은 응답 객체
+     * @throws BusinessException 해당 ID의 방이 존재하지 않거나 FINISHED 상태인 경우 ROOM_NOT_FOUND 예외 발생
+     */
+    public RoomDetailResponse getRoomDetail(Long roomId) {
+        GameRoom gameRoom = gameRoomRepository.findById(roomId)
+                .orElseThrow(() -> {
+                    log.warn("방을 찾을 수 없습니다. roomId={}", roomId);
+                    return new BusinessException(ErrorCode.ROOM_NOT_FOUND);
+                });
+
+        // FINISHED 상태인 방은 조회 불가
+        if (gameRoom.getStatus() == GameRoomStatus.FINISHED) {
+            log.warn("종료된 방은 조회할 수 없습니다. roomId={}, status={}", roomId, gameRoom.getStatus());
+            throw new BusinessException(ErrorCode.ROOM_NOT_FOUND);
+        }
+
+        log.info("방 상세 정보 조회 완료. roomId={}, gameTitle={}, status={}",
+                roomId, gameRoom.getGameTitle(), gameRoom.getStatus());
+
+        return RoomDetailResponse.from(gameRoom);
     }
 }

--- a/backend/src/test/java/app/signbell/backend/service/RoomListServiceTest.java
+++ b/backend/src/test/java/app/signbell/backend/service/RoomListServiceTest.java
@@ -1,0 +1,360 @@
+package app.signbell.backend.service;
+
+import app.signbell.backend.dto.response.RoomDetailResponse;
+import app.signbell.backend.dto.response.RoomListResponse;
+import app.signbell.backend.dto.response.RoomListSliceResponse;
+import app.signbell.backend.entity.*;
+import app.signbell.backend.exception.BusinessException;
+import app.signbell.backend.exception.ErrorCode;
+import app.signbell.backend.repository.GameParticipantRepository;
+import app.signbell.backend.repository.GameRoomRepository;
+import app.signbell.backend.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+/**
+ * RoomListServiceTest 클래스는 게임 방 목록 조회 서비스(RoomListService)의 통합 테스트를 수행하기 위한 클래스입니다.
+ *
+ * 이 테스트 클래스는 Spring Boot 환경에서 통합 테스트를 수행하며, 각 테스트는 @Transactional 어노테이션을 통해
+ * 데이터베이스의 변경 사항이 테스트 종료 후 자동으로 롤백됩니다.
+ *
+ * 주요 테스트 시나리오:
+ * - WAITING 상태의 방 목록이 정상적으로 조회되는지 확인
+ * - IN_PROGRESS 상태의 방 목록이 정상적으로 조회되는지 확인
+ * - FINISHED 상태의 방은 목록에서 제외되는지 확인
+ * - 페이징이 정상적으로 작동하는지 확인
+ * - 특정 방 상세 정보가 정상적으로 조회되는지 확인
+ * - 존재하지 않는 방 조회 시 예외가 발생하는지 확인
+ * - FINISHED 상태의 방 조회 시 예외가 발생하는지 확인
+ * - 빈 목록이 정상적으로 반환되는지 확인
+ * - 페이지 크기 유효성 검증이 작동하는지 확인
+ * - hasNext 플래그가 정확하게 동작하는지 확인
+ *
+ * 테스트 방법:
+ * - 사용자(User), 게임 방(GameRoom), 그리고 게임 참가자(GameParticipant)와 관련된 데이터를 JpaRepository를 사용해 데이터베이스에 직접 접근
+ * - 각 테스트는 given-when-then 패턴으로 작성되어 이해하기 쉽게 구성
+ * - 모든 테스트는 필요한 경우 사용자 또는 관련된 데이터의 초기 구성을 포함
+ *
+ * @author 강관주
+ * @since 2025-10-19
+ */
+@SpringBootTest
+@Transactional
+@DisplayName("RoomListService 테스트")
+class RoomListServiceTest {
+
+    @Autowired
+    private RoomListService roomListService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private GameRoomRepository gameRoomRepository;
+
+    @Autowired
+    private GameParticipantRepository gameParticipantRepository;
+
+    private User testUser1;
+    private User testUser2;
+    private User testUser3;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트 사용자들 생성
+        testUser1 = User.builder()
+                .nickname("testUser1")
+                .email("test1@example.com")
+                .provider(LoginMethod.KAKAO)
+                .providerId("111")
+                .build();
+        testUser1 = userRepository.save(testUser1);
+
+        testUser2 = User.builder()
+                .nickname("testUser2")
+                .email("test2@example.com")
+                .provider(LoginMethod.KAKAO)
+                .providerId("222")
+                .build();
+        testUser2 = userRepository.save(testUser2);
+
+        testUser3 = User.builder()
+                .nickname("testUser3")
+                .email("test3@example.com")
+                .provider(LoginMethod.KAKAO)
+                .providerId("333")
+                .build();
+        testUser3 = userRepository.save(testUser3);
+    }
+
+    @Test
+    @DisplayName("WAITING 상태의 방만 조회되어야 한다")
+    void getRoomList_OnlyWaitingRooms() {
+        // Given
+        GameRoom waitingRoom = createGameRoom("대기 중인 방", testUser1, GameRoomStatus.WAITING);
+
+        // When
+        RoomListSliceResponse response = roomListService.getRoomList(0, 10);
+
+        // Then
+        assertThat(response.getRoomList()).hasSize(1);
+        assertThat(response.getRoomList().get(0).getGameTitle()).isEqualTo("대기 중인 방");
+        assertThat(response.getRoomList().get(0).getStatus()).isEqualTo("WAITING");
+        assertThat(response.getHasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("IN_PROGRESS 상태의 방도 조회되어야 한다")
+    void getRoomList_InProgressRoomsIncluded() {
+        // Given
+        GameRoom inProgressRoom = createGameRoom("진행 중인 방", testUser1, GameRoomStatus.IN_PROGRESS);
+
+        // When
+        RoomListSliceResponse response = roomListService.getRoomList(0, 10);
+
+        // Then
+        assertThat(response.getRoomList()).hasSize(1);
+        assertThat(response.getRoomList().get(0).getStatus()).isEqualTo("IN_PROGRESS");
+    }
+
+    @Test
+    @DisplayName("WAITING과 IN_PROGRESS 상태의 방이 모두 조회되어야 한다")
+    void getRoomList_WaitingAndInProgressRooms() {
+        // Given
+        GameRoom waitingRoom = createGameRoom("대기 중인 방", testUser1, GameRoomStatus.WAITING);
+        GameRoom inProgressRoom = createGameRoom("진행 중인 방", testUser2, GameRoomStatus.IN_PROGRESS);
+
+        // When
+        RoomListSliceResponse response = roomListService.getRoomList(0, 10);
+
+        // Then
+        assertThat(response.getRoomList()).hasSize(2);
+        assertThat(response.getRoomList())
+                .extracting(RoomListResponse::getStatus)
+                .containsExactlyInAnyOrder("WAITING", "IN_PROGRESS");
+    }
+
+    @Test
+    @DisplayName("FINISHED 상태의 방은 목록에서 제외되어야 한다")
+    void getRoomList_FinishedRoomsExcluded() {
+        // Given
+        GameRoom waitingRoom = createGameRoom("대기 중인 방", testUser1, GameRoomStatus.WAITING);
+        GameRoom finishedRoom = createGameRoom("종료된 방", testUser2, GameRoomStatus.FINISHED);
+
+        // When
+        RoomListSliceResponse response = roomListService.getRoomList(0, 10);
+
+        // Then
+        assertThat(response.getRoomList()).hasSize(1);
+        assertThat(response.getRoomList().get(0).getStatus()).isEqualTo("WAITING");
+        assertThat(response.getRoomList())
+                .extracting(RoomListResponse::getGameTitle)
+                .doesNotContain("종료된 방");
+    }
+
+    @Test
+    @DisplayName("페이징이 정상적으로 작동해야 한다")
+    void getRoomList_PagingWorks() {
+        // Given - 5개의 방 생성
+        for (int i = 1; i <= 5; i++) {
+            createGameRoom("방" + i, testUser1, GameRoomStatus.WAITING);
+        }
+
+        // When - 페이지 크기를 2로 설정
+        RoomListSliceResponse page0 = roomListService.getRoomList(0, 2);
+        RoomListSliceResponse page1 = roomListService.getRoomList(1, 2);
+
+        // Then
+        assertThat(page0.getRoomList()).hasSize(2);
+        assertThat(page0.getHasNext()).isTrue();
+        assertThat(page1.getRoomList()).hasSize(2);
+        assertThat(page1.getHasNext()).isTrue();
+    }
+
+    @Test
+    @DisplayName("마지막 페이지에서 hasNext가 false여야 한다")
+    void getRoomList_LastPageHasNextFalse() {
+        // Given - 3개의 방 생성
+        createGameRoom("방1", testUser1, GameRoomStatus.WAITING);
+        createGameRoom("방2", testUser2, GameRoomStatus.WAITING);
+        createGameRoom("방3", testUser3, GameRoomStatus.WAITING);
+
+        // When - 페이지 크기를 5로 설정 (3개만 있으므로 한 페이지에 다 들어감)
+        RoomListSliceResponse response = roomListService.getRoomList(0, 5);
+
+        // Then
+        assertThat(response.getRoomList()).hasSize(3);
+        assertThat(response.getHasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("방이 없을 때 빈 목록이 반환되어야 한다")
+    void getRoomList_EmptyList() {
+        // Given - 방이 없음
+
+        // When
+        RoomListSliceResponse response = roomListService.getRoomList(0, 10);
+
+        // Then
+        assertThat(response.getRoomList()).isEmpty();
+        assertThat(response.getHasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 페이지 크기는 기본값 10으로 설정되어야 한다")
+    void getRoomList_InvalidSizeDefaultsTo10() {
+        // Given - 15개의 방 생성
+        for (int i = 1; i <= 15; i++) {
+            createGameRoom("방" + i, testUser1, GameRoomStatus.WAITING);
+        }
+
+        // When - 유효하지 않은 페이지 크기 (0, 101)
+        RoomListSliceResponse response1 = roomListService.getRoomList(0, 0);
+        RoomListSliceResponse response2 = roomListService.getRoomList(0, 101);
+
+        // Then - 기본값 10으로 조회됨
+        assertThat(response1.getRoomList()).hasSize(10);
+        assertThat(response2.getRoomList()).hasSize(10);
+    }
+
+    @Test
+    @DisplayName("특정 방의 상세 정보가 정상적으로 조회되어야 한다")
+    void getRoomDetail_Success() {
+        // Given
+        GameRoom room = createGameRoom("테스트 방", testUser1, GameRoomStatus.WAITING);
+
+        // When
+        RoomDetailResponse response = roomListService.getRoomDetail(room.getId());
+
+        // Then
+        assertThat(response).isNotNull();
+        assertThat(response.getGameRoomId()).isEqualTo(room.getId());
+        assertThat(response.getGameTitle()).isEqualTo("테스트 방");
+        assertThat(response.getCurrentParticipants()).isEqualTo(1);
+        assertThat(response.getMaxParticipants()).isEqualTo(4);
+        assertThat(response.getStatus()).isEqualTo("WAITING");
+    }
+
+    @Test
+    @DisplayName("IN_PROGRESS 상태의 방 상세 정보도 조회되어야 한다")
+    void getRoomDetail_InProgressRoom() {
+        // Given
+        GameRoom room = createGameRoom("진행 중인 방", testUser1, GameRoomStatus.IN_PROGRESS);
+
+        // When
+        RoomDetailResponse response = roomListService.getRoomDetail(room.getId());
+
+        // Then
+        assertThat(response.getStatus()).isEqualTo("IN_PROGRESS");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 방 조회 시 예외가 발생해야 한다")
+    void getRoomDetail_RoomNotFound() {
+        // Given
+        Long nonExistentRoomId = 99999L;
+
+        // When & Then
+        assertThatThrownBy(() -> roomListService.getRoomDetail(nonExistentRoomId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("FINISHED 상태의 방 조회 시 예외가 발생해야 한다")
+    void getRoomDetail_FinishedRoomThrowsException() {
+        // Given
+        GameRoom finishedRoom = createGameRoom("종료된 방", testUser1, GameRoomStatus.FINISHED);
+
+        // When & Then
+        assertThatThrownBy(() -> roomListService.getRoomDetail(finishedRoom.getId()))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROOM_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("방 목록은 최신 생성순으로 정렬되어야 한다")
+    void getRoomList_OrderedByCreatedAtDesc() throws InterruptedException {
+        // Given - 순차적으로 방 생성
+        GameRoom room1 = createGameRoom("첫 번째 방", testUser1, GameRoomStatus.WAITING);
+        Thread.sleep(10); // 생성 시간 차이를 위해
+        GameRoom room2 = createGameRoom("두 번째 방", testUser2, GameRoomStatus.WAITING);
+        Thread.sleep(10);
+        GameRoom room3 = createGameRoom("세 번째 방", testUser3, GameRoomStatus.WAITING);
+
+        // When
+        RoomListSliceResponse response = roomListService.getRoomList(0, 10);
+
+        // Then - 최신순으로 정렬됨 (세 번째 -> 두 번째 -> 첫 번째)
+        assertThat(response.getRoomList()).hasSize(3);
+        assertThat(response.getRoomList().get(0).getGameTitle()).isEqualTo("세 번째 방");
+        assertThat(response.getRoomList().get(1).getGameTitle()).isEqualTo("두 번째 방");
+        assertThat(response.getRoomList().get(2).getGameTitle()).isEqualTo("첫 번째 방");
+    }
+
+    @Test
+    @DisplayName("다양한 상태가 혼재된 경우 WAITING과 IN_PROGRESS만 조회되어야 한다")
+    void getRoomList_MixedStatuses() {
+        // Given
+        createGameRoom("대기1", testUser1, GameRoomStatus.WAITING);
+        createGameRoom("진행1", testUser2, GameRoomStatus.IN_PROGRESS);
+        createGameRoom("종료1", testUser3, GameRoomStatus.FINISHED);
+        createGameRoom("대기2", testUser1, GameRoomStatus.WAITING);
+        createGameRoom("진행2", testUser2, GameRoomStatus.IN_PROGRESS);
+        createGameRoom("종료2", testUser3, GameRoomStatus.FINISHED);
+
+        // When
+        RoomListSliceResponse response = roomListService.getRoomList(0, 10);
+
+        // Then
+        assertThat(response.getRoomList()).hasSize(4);
+        assertThat(response.getRoomList())
+                .extracting(RoomListResponse::getStatus)
+                .containsOnly("WAITING", "IN_PROGRESS")
+                .doesNotContain("FINISHED");
+    }
+
+    @Test
+    @DisplayName("방 상세 정보 조회 시 방장 정보가 포함되지 않아야 한다")
+    void getRoomDetail_NoHostNickname() {
+        // Given
+        GameRoom room = createGameRoom("테스트 방", testUser1, GameRoomStatus.WAITING);
+
+        // When
+        RoomDetailResponse response = roomListService.getRoomDetail(room.getId());
+
+        // Then - RoomDetailResponse에는 hostNickname 필드가 없음을 확인
+        assertThat(response.getGameRoomId()).isNotNull();
+        assertThat(response.getGameTitle()).isNotNull();
+        assertThat(response.getCurrentParticipants()).isNotNull();
+        assertThat(response.getMaxParticipants()).isNotNull();
+        assertThat(response.getStatus()).isNotNull();
+    }
+
+    // 헬퍼 메서드
+    private GameRoom createGameRoom(String title, User host, GameRoomStatus status) {
+        GameRoom room = GameRoom.builder()
+                .gameTitle(title)
+                .host(host)
+                .status(status)
+                .build();
+        room = gameRoomRepository.save(room);
+
+        // 방장을 참가자로 등록
+        GameParticipant hostParticipant = GameParticipant.builder()
+                .gameRoom(room)
+                .participant(host)
+                .isHost(true)
+                .build();
+        gameParticipantRepository.save(hostParticipant);
+
+        return room;
+    }
+}


### PR DESCRIPTION
# Pull Request

## PR 유형 (Type of PR)
- [x] 기능 (Feature)
- [ ] 버그 수정 (Bugfix)
- [x] 기능 개선 (Enhancement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)

이 PR은 게임 방 조회 기능을 개선하고 새로운 상세 조회 API를 추가합니다.

**주요 변경 사항:**
1. 방 번호로 특정 게임 방의 상세 정보를 조회할 수 있는 API 추가
2. 방 목록 조회 시 WAITING 상태뿐만 아니라 IN_PROGRESS 상태의 방도 함께 조회되도록 개선
3. FINISHED 상태의 방은 목록 및 상세 조회에서 제외
4. 통합 테스트 추가로 기능 안정성 확보

---

## 관련 이슈 (Related Issue)

- Closes #50 
- Closes #51 

---

## 변경 사항 (Changes)

### 1. 새로운 API 엔드포인트 추가
- `GET /api/quiz/rooms/{roomId}` 엔드포인트 추가
- 방 번호를 통한 직접 검색 기능 제공
- 인증된 사용자만 접근 가능

### 2. Response DTO 추가
- `RoomDetailResponse` 클래스 신규 생성
  - `gameRoomId`, `gameTitle`, `currentParticipants`, `maxParticipants`, `status` 필드 포함
  - 정적 팩토리 메서드 `from(GameRoom)` 제공

### 3. Repository Layer 개선
- `GameRoomRepositoryCustom`: `findWaitingRooms` → `findActiveRooms` 메서드명 변경
- `GameRoomRepositoryImpl`: QueryDSL 쿼리 조건 수정
  - 기존: `gameRoom.status.eq(GameRoomStatus.WAITING)`
  - 변경: `gameRoom.status.in(GameRoomStatus.WAITING, GameRoomStatus.IN_PROGRESS)`

### 4. Service Layer 개선
- `RoomListService`
  - `getRoomDetail(Long roomId)` 메서드 추가
  - FINISHED 상태 방 조회 시 `ROOM_NOT_FOUND` 예외 발생
  - 존재하지 않는 방 조회 시 예외 처리
  - 방 목록 조회 시 활성 상태(WAITING, IN_PROGRESS) 방만 반환

### 5. Controller Layer 확장
- `RoomListController`
  - `GET /{roomId}` 엔드포인트 추가
  - `@PathVariable`로 roomId 수신
  - 인증 처리 및 로깅 추가

### 6. 테스트 코드 추가
- `RoomListServiceTest` 클래스 추가 (15개 테스트 케이스)
  - WAITING/IN_PROGRESS 상태 필터링 검증
  - FINISHED 상태 방 제외 검증
  - 페이징 동작 및 hasNext 플래그 검증
  - 방 상세 조회 및 예외 처리 검증
  - 정렬 순서 및 빈 목록 처리 검증

---

## 스크린샷 (Screenshots)

### 테스트 결과

<img width="529" height="424" alt="RoomListServiceTest" src="https://github.com/user-attachments/assets/a1b42eac-777c-45e7-a86d-3862f37dbe2d" />

---

## 테스트 방법 (Test Steps)

### 1. 방 목록 조회 테스트
```bash
# WAITING 및 IN_PROGRESS 상태의 방이 조회되는지 확인
GET /api/quiz/rooms?page=0&size=10
Authorization: Bearer {token}
```

**예상 결과:**
- WAITING과 IN_PROGRESS 상태의 방 모두 포함
- FINISHED 상태의 방은 제외
- hasNext 플래그 정상 작동

### 2. 방 상세 조회 테스트
```bash
# 특정 방 번호로 상세 정보 조회
GET /api/quiz/rooms/{roomId}
Authorization: Bearer {token}
```

**예상 결과:**
- 방이 존재하고 WAITING/IN_PROGRESS 상태인 경우: 200 OK + 방 정보 반환
- 방이 존재하지 않는 경우: 404 ROOM_NOT_FOUND
- FINISHED 상태의 방: 404 ROOM_NOT_FOUND

### 3. 통합 테스트 실행
```bash
# RoomListServiceTest 실행
./gradlew test --tests RoomListServiceTest
```

**예상 결과:**
- 15개 테스트 케이스 모두 통과

---

## 셀프 체크리스트 (Self-Checklist)

- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [ ] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)

### 주요 리뷰 포인트

1. **Repository 쿼리 변경 검토**
   - `GameRoomRepositoryImpl`의 QueryDSL 쿼리가 IN_PROGRESS 상태를 올바르게 포함하는지 확인
   - N+1 문제 방지를 위한 fetch join이 적절히 유지되는지 검토

2. **예외 처리 로직**
   - FINISHED 상태 방 조회 시 `ROOM_NOT_FOUND` 예외 발생이 적절한지 확인
   - 존재하지 않는 방과 FINISHED 방을 동일한 예외로 처리하는 것이 맞는지 검토

3. **하위 호환성**
   - 기존 클라이언트에 영향이 없는지 확인
   - API 응답 구조는 동일하며, 단순히 조회되는 방의 종류만 증가

4. **테스트 커버리지**
   - 15개의 통합 테스트가 주요 시나리오를 충분히 커버하는지 확인
   - 추가로 필요한 테스트 케이스가 있는지 의견 부탁드립니다

### 참고 사항
- 메서드명 변경: `findWaitingRooms` → `findActiveRooms` (의미를 더 명확하게 표현)
- 모든 JavaDoc 및 주석도 함께 업데이트했습니다
- 로깅 메시지도 변경 사항에 맞게 수정했습니다

