### PR TITLE
[Feat]: 마이페이지 UI/UX 구현 (#80)

### DIFF
--- a/frontend/src/components/common/Header.jsx
+++ b/frontend/src/components/common/Header.jsx
@@ -8,7 +8,7 @@
 
 import { useNavigate, useLocation } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faUser, faRightFromBracket } from '@fortawesome/free-solid-svg-icons';
+import { faUser, faRightFromBracket, faArrowLeft } from '@fortawesome/free-solid-svg-icons';
 import styles from './Header.module.scss';
 
 const Header = () => {
@@ -19,14 +19,19 @@ const Header = () => {
     // 메인 페이지에서는 새로고침, 다른 페이지에서는 메인으로 이동
     if (location.pathname === '/main') {
       window.location.reload();
+    } else if (location.pathname === '/mypage') {
+      navigate('/main');
     } else {
       navigate('/');
     }
   };
 
   const handleMyPageClick = () => {
-    // TODO: 마이페이지 구현 후 연결
-    console.log('마이페이지로 이동');
+    navigate('/mypage');
+  };
+
+  const handleBackClick = () => {
+    navigate('/main');
   };
 
   const handleLogoutClick = () => {
@@ -37,6 +42,8 @@ const Header = () => {
 
   // 메인 페이지에서만 마이페이지와 로그아웃 버튼 표시
   const showMainPageButtons = location.pathname === '/main';
+  // 마이페이지에서는 뒤로가기 버튼 표시
+  const showBackButton = location.pathname === '/mypage';
 
   return (
     <header className={styles.header}>
@@ -64,6 +71,16 @@ const Header = () => {
                 <span>로그아웃</span>
               </button>
             </>
+          )}
+          {showBackButton && (
+            <button
+              className={`${styles.headerButton} ${styles.backButton}`}
+              onClick={handleBackClick}
+              aria-label="뒤로가기"
+            >
+              <FontAwesomeIcon icon={faArrowLeft} />
+              <span>뒤로가기</span>
+            </button>
           )}
         </div>
       </div>

--- a/frontend/src/components/common/Header.module.scss
+++ b/frontend/src/components/common/Header.module.scss
@@ -88,6 +88,16 @@
           }
         }
 
+        &.back-button {
+          background-color: var(--secondary-color);
+          color: var(--white-color);
+
+          &:hover {
+            background-color: #64b5f6;
+            box-shadow: 0 4px 8px rgba(144, 202, 249, 0.3);
+          }
+        }
+
         @media (max-width: 768px) {
           padding: 6px 12px;
           font-size: 13px;

--- a/frontend/src/components/main/UserProfileCard.jsx
+++ b/frontend/src/components/main/UserProfileCard.jsx
@@ -7,11 +7,14 @@
  */
 
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPenToSquare, faCoins, faUser } from '@fortawesome/free-solid-svg-icons';
 import styles from './UserProfileCard.module.scss';
 
 const UserProfileCard = () => {
+  const navigate = useNavigate();
+  
   // TODO: 사용자 프로필 API 연동 필요
   const userProfile = {
     nickname: '사용자',
@@ -22,8 +25,7 @@ const UserProfileCard = () => {
   const [imageError, setImageError] = useState(false);
 
   const handleEditClick = () => {
-    // TODO: 마이페이지 구현 후 연결
-    console.log('닉네임 수정 클릭');
+    navigate('/mypage');
   };
 
   const handleImageError = () => {

--- a/frontend/src/components/mypage/NicknameEditor.jsx
+++ b/frontend/src/components/mypage/NicknameEditor.jsx
@@ -50,6 +50,13 @@ const NicknameEditor = () => {
     alert('닉네임이 수정되었습니다.');
   };
 
+  const handleKeyPress = (e) => {
+    // Enter 키로 제출
+    if (e.key === 'Enter' && !isSubmitDisabled) {
+      handleSubmit();
+    }
+  };
+
   // 원본과 다르고, 에러가 없고, 비어있지 않을 때만 수정 버튼 활성화
   const isModified = nickname.trim() !== originalNickname;
   const isSubmitDisabled = !isModified || error !== '' || nickname.trim() === '';
@@ -65,18 +72,21 @@ const NicknameEditor = () => {
           type="text"
           value={nickname}
           onChange={handleNicknameChange}
+          onKeyPress={handleKeyPress}
           className={`${styles.input} ${error ? styles.inputError : ''}`}
           placeholder="닉네임을 입력하세요"
           maxLength={10}
           aria-label="닉네임 입력"
           aria-invalid={error !== ''}
           aria-describedby={error ? 'nickname-error' : undefined}
+          autoComplete="nickname"
         />
         <button
           onClick={handleSubmit}
           disabled={isSubmitDisabled}
           className={styles.submitButton}
           aria-label="닉네임 수정"
+          title="닉네임 수정"
         >
           수정
         </button>

--- a/frontend/src/components/mypage/NicknameEditor.jsx
+++ b/frontend/src/components/mypage/NicknameEditor.jsx
@@ -1,0 +1,91 @@
+/**
+ * @개요 닉네임 수정 컴포넌트
+ * @작성자 신동준 (sdj3959)
+ * @작성일 2025-10-23
+ * @최종수정일 2025-10-23
+ * @반환값 {JSX.Element} 닉네임 수정 컴포넌트
+ */
+
+import { useState } from 'react';
+import styles from './NicknameEditor.module.scss';
+
+const NicknameEditor = () => {
+  // TODO: 사용자 프로필 API 연동 필요
+  const [nickname, setNickname] = useState('사용자');
+  const [error, setError] = useState('');
+  const [isModified, setIsModified] = useState(false);
+
+  const validateNickname = (value) => {
+    if (value.length < 2) {
+      return '닉네임은 2자 이상이어야 합니다.';
+    }
+    if (value.length > 10) {
+      return '닉네임은 10자 이하여야 합니다.';
+    }
+    // 특수문자 필터링 (한글, 영문, 숫자만 허용)
+    const regex = /^[가-힣a-zA-Z0-9]+$/;
+    if (!regex.test(value)) {
+      return '닉네임은 한글, 영문, 숫자만 사용 가능합니다.';
+    }
+    return '';
+  };
+
+  const handleNicknameChange = (e) => {
+    const value = e.target.value;
+    setNickname(value);
+    setIsModified(true);
+    
+    const validationError = validateNickname(value);
+    setError(validationError);
+  };
+
+  const handleSubmit = () => {
+    const validationError = validateNickname(nickname);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    // TODO: 닉네임 수정 API 연동 필요
+    console.log('닉네임 수정:', nickname);
+    alert('닉네임이 수정되었습니다.');
+    setIsModified(false);
+  };
+
+  const isSubmitDisabled = !isModified || error !== '' || nickname.trim() === '';
+
+  return (
+    <div className={styles.nicknameEditor}>
+      <label htmlFor="nickname" className={styles.label}>
+        닉네임
+      </label>
+      <input
+        id="nickname"
+        type="text"
+        value={nickname}
+        onChange={handleNicknameChange}
+        className={`${styles.input} ${error ? styles.inputError : ''}`}
+        placeholder="닉네임을 입력하세요"
+        maxLength={10}
+        aria-label="닉네임 입력"
+        aria-invalid={error !== ''}
+        aria-describedby={error ? 'nickname-error' : undefined}
+      />
+      {error && (
+        <p id="nickname-error" className={styles.errorMessage} role="alert">
+          {error}
+        </p>
+      )}
+      <button
+        onClick={handleSubmit}
+        disabled={isSubmitDisabled}
+        className={styles.submitButton}
+        aria-label="닉네임 수정"
+      >
+        수정
+      </button>
+    </div>
+  );
+};
+
+export default NicknameEditor;

--- a/frontend/src/components/mypage/NicknameEditor.jsx
+++ b/frontend/src/components/mypage/NicknameEditor.jsx
@@ -16,15 +16,20 @@ const NicknameEditor = () => {
   const [error, setError] = useState('');
 
   const validateNickname = (value) => {
-    if (value.trim().length < 2) {
+    const trimmedValue = value.trim();
+    
+    if (trimmedValue.length === 0) {
+      return '닉네임을 입력해주세요.';
+    }
+    if (trimmedValue.length < 2) {
       return '닉네임은 2자 이상이어야 합니다.';
     }
-    if (value.trim().length > 10) {
+    if (trimmedValue.length > 10) {
       return '닉네임은 10자 이하여야 합니다.';
     }
     // 특수문자 필터링 (한글, 영문, 숫자만 허용)
     const regex = /^[가-힣a-zA-Z0-9]+$/;
-    if (!regex.test(value.trim())) {
+    if (!regex.test(trimmedValue)) {
       return '닉네임은 한글, 영문, 숫자만 사용 가능합니다.';
     }
     return '';
@@ -34,8 +39,13 @@ const NicknameEditor = () => {
     const value = e.target.value;
     setNickname(value);
     
-    const validationError = validateNickname(value);
-    setError(validationError);
+    // 입력 중에는 에러 메시지를 표시하지 않음 (빈 값 제외)
+    if (value.trim().length > 0) {
+      const validationError = validateNickname(value);
+      setError(validationError);
+    } else {
+      setError('');
+    }
   };
 
   const handleSubmit = () => {

--- a/frontend/src/components/mypage/NicknameEditor.jsx
+++ b/frontend/src/components/mypage/NicknameEditor.jsx
@@ -3,13 +3,14 @@
  * @작성자 신동준 (sdj3959)
  * @작성일 2025-10-23
  * @최종수정일 2025-10-23
+ * @매개변수 {Function} props.onNicknameUpdate - 닉네임 수정 성공 시 호출되는 콜백 함수
  * @반환값 {JSX.Element} 닉네임 수정 컴포넌트
  */
 
 import { useState } from 'react';
 import styles from './NicknameEditor.module.scss';
 
-const NicknameEditor = () => {
+const NicknameEditor = ({ onNicknameUpdate }) => {
   // TODO: 사용자 프로필 API 연동 필요
   const [originalNickname] = useState('사용자'); // 원본 닉네임 저장
   const [nickname, setNickname] = useState('사용자');
@@ -55,9 +56,15 @@ const NicknameEditor = () => {
       return;
     }
 
+    const trimmedNickname = nickname.trim();
+    
     // TODO: 닉네임 수정 API 연동 필요
-    console.log('닉네임 수정:', nickname.trim());
-    alert('닉네임이 수정되었습니다.');
+    console.log('닉네임 수정:', trimmedNickname);
+    
+    // 부모 컴포넌트에 닉네임 업데이트 알림
+    if (onNicknameUpdate) {
+      onNicknameUpdate(trimmedNickname);
+    }
   };
 
   const handleKeyPress = (e) => {

--- a/frontend/src/components/mypage/NicknameEditor.jsx
+++ b/frontend/src/components/mypage/NicknameEditor.jsx
@@ -11,20 +11,20 @@ import styles from './NicknameEditor.module.scss';
 
 const NicknameEditor = () => {
   // TODO: 사용자 프로필 API 연동 필요
+  const [originalNickname] = useState('사용자'); // 원본 닉네임 저장
   const [nickname, setNickname] = useState('사용자');
   const [error, setError] = useState('');
-  const [isModified, setIsModified] = useState(false);
 
   const validateNickname = (value) => {
-    if (value.length < 2) {
+    if (value.trim().length < 2) {
       return '닉네임은 2자 이상이어야 합니다.';
     }
-    if (value.length > 10) {
+    if (value.trim().length > 10) {
       return '닉네임은 10자 이하여야 합니다.';
     }
     // 특수문자 필터링 (한글, 영문, 숫자만 허용)
     const regex = /^[가-힣a-zA-Z0-9]+$/;
-    if (!regex.test(value)) {
+    if (!regex.test(value.trim())) {
       return '닉네임은 한글, 영문, 숫자만 사용 가능합니다.';
     }
     return '';
@@ -33,7 +33,6 @@ const NicknameEditor = () => {
   const handleNicknameChange = (e) => {
     const value = e.target.value;
     setNickname(value);
-    setIsModified(true);
     
     const validationError = validateNickname(value);
     setError(validationError);
@@ -47,11 +46,12 @@ const NicknameEditor = () => {
     }
 
     // TODO: 닉네임 수정 API 연동 필요
-    console.log('닉네임 수정:', nickname);
+    console.log('닉네임 수정:', nickname.trim());
     alert('닉네임이 수정되었습니다.');
-    setIsModified(false);
   };
 
+  // 원본과 다르고, 에러가 없고, 비어있지 않을 때만 수정 버튼 활성화
+  const isModified = nickname.trim() !== originalNickname;
   const isSubmitDisabled = !isModified || error !== '' || nickname.trim() === '';
 
   return (

--- a/frontend/src/components/mypage/NicknameEditor.jsx
+++ b/frontend/src/components/mypage/NicknameEditor.jsx
@@ -59,31 +59,35 @@ const NicknameEditor = () => {
       <label htmlFor="nickname" className={styles.label}>
         닉네임
       </label>
-      <input
-        id="nickname"
-        type="text"
-        value={nickname}
-        onChange={handleNicknameChange}
-        className={`${styles.input} ${error ? styles.inputError : ''}`}
-        placeholder="닉네임을 입력하세요"
-        maxLength={10}
-        aria-label="닉네임 입력"
-        aria-invalid={error !== ''}
-        aria-describedby={error ? 'nickname-error' : undefined}
-      />
-      {error && (
-        <p id="nickname-error" className={styles.errorMessage} role="alert">
-          {error}
-        </p>
-      )}
-      <button
-        onClick={handleSubmit}
-        disabled={isSubmitDisabled}
-        className={styles.submitButton}
-        aria-label="닉네임 수정"
-      >
-        수정
-      </button>
+      <div className={styles.inputWrapper}>
+        <input
+          id="nickname"
+          type="text"
+          value={nickname}
+          onChange={handleNicknameChange}
+          className={`${styles.input} ${error ? styles.inputError : ''}`}
+          placeholder="닉네임을 입력하세요"
+          maxLength={10}
+          aria-label="닉네임 입력"
+          aria-invalid={error !== ''}
+          aria-describedby={error ? 'nickname-error' : undefined}
+        />
+        <button
+          onClick={handleSubmit}
+          disabled={isSubmitDisabled}
+          className={styles.submitButton}
+          aria-label="닉네임 수정"
+        >
+          수정
+        </button>
+      </div>
+      <div className={styles.errorMessage}>
+        {error && (
+          <span id="nickname-error" role="alert">
+            {error}
+          </span>
+        )}
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/mypage/NicknameEditor.module.scss
+++ b/frontend/src/components/mypage/NicknameEditor.module.scss
@@ -131,8 +131,17 @@
 
 // 반응형 디자인
 @media (max-width: 768px) {
+  .nicknameEditor {
+    margin-bottom: 24px;
+  }
+
+  .label {
+    font-size: 13px;
+  }
+
   .inputWrapper {
     flex-direction: column;
+    min-height: auto;
   }
 
   .input {
@@ -143,5 +152,21 @@
   .submitButton {
     width: 100%;
     padding: 12px 24px;
+  }
+
+  .errorMessage {
+    font-size: 12px;
+  }
+}
+
+@media (max-width: 480px) {
+  .input {
+    font-size: 14px;
+    padding: 10px 12px;
+  }
+
+  .submitButton {
+    padding: 10px 20px;
+    font-size: 13px;
   }
 }

--- a/frontend/src/components/mypage/NicknameEditor.module.scss
+++ b/frontend/src/components/mypage/NicknameEditor.module.scss
@@ -1,0 +1,130 @@
+/**
+ * @개요 닉네임 수정 컴포넌트 스타일
+ * @작성자 신동준 (sdj3959)
+ * @작성일 2025-10-23
+ * @최종수정일 2025-10-23
+ */
+
+.nicknameEditor {
+  margin-bottom: 32px;
+  animation: fadeInUp 0.6s ease-out 0.3s both;
+}
+
+.label {
+  display: block;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-color);
+  margin-bottom: 8px;
+}
+
+.input {
+  width: 100%;
+  background-color: var(--background-color);
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 12px 16px;
+  font-size: 16px;
+  color: var(--text-color);
+  transition: all 0.3s ease;
+  box-sizing: border-box;
+
+  &::placeholder {
+    color: #9e9e9e;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: var(--secondary-color);
+    box-shadow: 0 0 0 3px rgba(144, 202, 249, 0.1);
+  }
+
+  &:hover:not(:focus) {
+    border-color: #bdbdbd;
+  }
+}
+
+.inputError {
+  border-color: #f44336;
+
+  &:focus {
+    border-color: #f44336;
+    box-shadow: 0 0 0 3px rgba(244, 67, 54, 0.1);
+  }
+}
+
+.errorMessage {
+  margin: 8px 0 0 0;
+  font-size: 13px;
+  color: #f44336;
+  animation: fadeIn 0.3s ease-out;
+}
+
+.submitButton {
+  margin-top: 12px;
+  background-color: var(--secondary-color);
+  color: var(--white-color);
+  border: none;
+  border-radius: 8px;
+  padding: 10px 24px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(144, 202, 249, 0.2);
+
+  &:hover:not(:disabled) {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(144, 202, 249, 0.3);
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.98);
+  }
+
+  &:focus {
+    outline: 2px solid var(--secondary-color);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    background-color: #e0e0e0;
+    color: #9e9e9e;
+    cursor: not-allowed;
+    box-shadow: none;
+  }
+}
+
+// 애니메이션
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+// 반응형 디자인
+@media (max-width: 768px) {
+  .input {
+    font-size: 15px;
+    padding: 10px 14px;
+  }
+
+  .submitButton {
+    width: 100%;
+    padding: 12px 24px;
+  }
+}

--- a/frontend/src/components/mypage/NicknameEditor.module.scss
+++ b/frontend/src/components/mypage/NicknameEditor.module.scss
@@ -18,8 +18,15 @@
   margin-bottom: 8px;
 }
 
+.inputWrapper {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+  min-height: 44px; // 버튼 높이와 동일하게 설정하여 카드 크기 고정
+}
+
 .input {
-  width: 100%;
+  flex: 1;
   background-color: var(--background-color);
   border: 1px solid #e0e0e0;
   border-radius: 8px;
@@ -58,10 +65,10 @@
   font-size: 13px;
   color: #f44336;
   animation: fadeIn 0.3s ease-out;
+  min-height: 18px; // 에러 메시지 공간 확보하여 카드 크기 고정
 }
 
 .submitButton {
-  margin-top: 12px;
   background-color: var(--secondary-color);
   color: var(--white-color);
   border: none;
@@ -72,6 +79,8 @@
   cursor: pointer;
   transition: all 0.3s ease;
   box-shadow: 0 2px 4px rgba(144, 202, 249, 0.2);
+  white-space: nowrap;
+  height: 44px; // 입력 필드와 동일한 높이
 
   &:hover:not(:disabled) {
     transform: translateY(-2px);
@@ -83,6 +92,10 @@
   }
 
   &:focus {
+    outline: none; // 기본 outline 제거
+  }
+
+  &:focus-visible {
     outline: 2px solid var(--secondary-color);
     outline-offset: 2px;
   }
@@ -118,6 +131,10 @@
 
 // 반응형 디자인
 @media (max-width: 768px) {
+  .inputWrapper {
+    flex-direction: column;
+  }
+
   .input {
     font-size: 15px;
     padding: 10px 14px;

--- a/frontend/src/components/mypage/ProfileImageEditor.jsx
+++ b/frontend/src/components/mypage/ProfileImageEditor.jsx
@@ -1,0 +1,97 @@
+/**
+ * @개요 프로필 이미지 수정 컴포넌트
+ * @작성자 신동준 (sdj3959)
+ * @작성일 2025-10-23
+ * @최종수정일 2025-10-23
+ * @반환값 {JSX.Element} 프로필 이미지 수정 컴포넌트
+ */
+
+import { useState, useRef } from 'react';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faUser, faCamera } from '@fortawesome/free-solid-svg-icons';
+import styles from './ProfileImageEditor.module.scss';
+
+const ProfileImageEditor = () => {
+  // TODO: 사용자 프로필 API 연동 필요
+  const [profileImage, setProfileImage] = useState(null);
+  const [imageError, setImageError] = useState(false);
+  const fileInputRef = useRef(null);
+
+  const handleImageClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleFileChange = (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    // 파일 형식 검증
+    const validTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif'];
+    if (!validTypes.includes(file.type)) {
+      alert('JPG, PNG, GIF 형식의 이미지만 업로드 가능합니다.');
+      return;
+    }
+
+    // 파일 크기 검증 (5MB)
+    const maxSize = 5 * 1024 * 1024;
+    if (file.size > maxSize) {
+      alert('이미지 크기는 5MB 이하여야 합니다.');
+      return;
+    }
+
+    // 이미지 미리보기
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      setProfileImage(e.target.result);
+      setImageError(false);
+      // TODO: 이미지 업로드 API 연동 필요
+      console.log('이미지 선택됨:', file.name);
+    };
+    reader.onerror = () => {
+      alert('이미지를 불러오는데 실패했습니다.');
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const handleImageError = () => {
+    setImageError(true);
+  };
+
+  return (
+    <div className={styles.profileImageEditor}>
+      <div className={styles.imageContainer}>
+        {profileImage && !imageError ? (
+          <img
+            src={profileImage}
+            alt="프로필 이미지"
+            className={styles.profileImage}
+            onError={handleImageError}
+          />
+        ) : (
+          <div className={styles.imagePlaceholder}>
+            <FontAwesomeIcon icon={faUser} />
+          </div>
+        )}
+        
+        <button
+          className={styles.cameraButton}
+          onClick={handleImageClick}
+          aria-label="프로필 이미지 변경"
+        >
+          <FontAwesomeIcon icon={faCamera} />
+        </button>
+      </div>
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/jpeg,image/jpg,image/png,image/gif"
+        onChange={handleFileChange}
+        className={styles.fileInput}
+        aria-label="이미지 파일 선택"
+      />
+    </div>
+  );
+};
+
+export default ProfileImageEditor;

--- a/frontend/src/components/mypage/ProfileImageEditor.jsx
+++ b/frontend/src/components/mypage/ProfileImageEditor.jsx
@@ -29,6 +29,10 @@ const ProfileImageEditor = () => {
     const validTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif'];
     if (!validTypes.includes(file.type)) {
       alert('JPG, PNG, GIF 형식의 이미지만 업로드 가능합니다.');
+      // 파일 input 초기화
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
       return;
     }
 
@@ -36,6 +40,10 @@ const ProfileImageEditor = () => {
     const maxSize = 5 * 1024 * 1024;
     if (file.size > maxSize) {
       alert('이미지 크기는 5MB 이하여야 합니다.');
+      // 파일 input 초기화
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
       return;
     }
 
@@ -49,6 +57,10 @@ const ProfileImageEditor = () => {
     };
     reader.onerror = () => {
       alert('이미지를 불러오는데 실패했습니다.');
+      // 파일 input 초기화
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
     };
     reader.readAsDataURL(file);
   };
@@ -77,8 +89,9 @@ const ProfileImageEditor = () => {
           className={styles.cameraButton}
           onClick={handleImageClick}
           aria-label="프로필 이미지 변경"
+          title="프로필 이미지 변경"
         >
-          <FontAwesomeIcon icon={faCamera} />
+          <FontAwesomeIcon icon={faCamera} aria-hidden="true" />
         </button>
       </div>
 
@@ -89,6 +102,7 @@ const ProfileImageEditor = () => {
         onChange={handleFileChange}
         className={styles.fileInput}
         aria-label="이미지 파일 선택"
+        tabIndex={-1}
       />
     </div>
   );

--- a/frontend/src/components/mypage/ProfileImageEditor.module.scss
+++ b/frontend/src/components/mypage/ProfileImageEditor.module.scss
@@ -1,0 +1,109 @@
+/**
+ * @개요 프로필 이미지 수정 컴포넌트 스타일
+ * @작성자 신동준 (sdj3959)
+ * @작성일 2025-10-23
+ * @최종수정일 2025-10-23
+ */
+
+.profileImageEditor {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 32px;
+  animation: scaleIn 0.5s ease-out 0.2s both;
+}
+
+.imageContainer {
+  position: relative;
+  width: 120px;
+  height: 120px;
+}
+
+.profileImage {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 4px solid var(--secondary-color);
+  background-color: var(--background-color);
+}
+
+.imagePlaceholder {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+  background-color: var(--background-color);
+  border: 4px solid var(--secondary-color);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--secondary-color);
+  font-size: 48px;
+}
+
+.cameraButton {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: var(--accent-color);
+  border: 3px solid var(--white-color);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  transition: all 0.3s ease;
+  color: var(--white-color);
+  font-size: 16px;
+
+  &:hover {
+    transform: scale(1.1);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+
+  &:focus {
+    outline: 2px solid var(--secondary-color);
+    outline-offset: 2px;
+  }
+}
+
+.fileInput {
+  display: none;
+}
+
+// 애니메이션
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.9);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+// 반응형 디자인
+@media (max-width: 768px) {
+  .imageContainer {
+    width: 100px;
+    height: 100px;
+  }
+
+  .imagePlaceholder {
+    font-size: 40px;
+  }
+
+  .cameraButton {
+    width: 32px;
+    height: 32px;
+    font-size: 14px;
+  }
+}

--- a/frontend/src/components/mypage/ProfileImageEditor.module.scss
+++ b/frontend/src/components/mypage/ProfileImageEditor.module.scss
@@ -69,6 +69,10 @@
   }
 
   &:focus {
+    outline: none; // 기본 outline 제거
+  }
+
+  &:focus-visible {
     outline: 2px solid var(--secondary-color);
     outline-offset: 2px;
   }

--- a/frontend/src/components/mypage/ProfileImageEditor.module.scss
+++ b/frontend/src/components/mypage/ProfileImageEditor.module.scss
@@ -96,9 +96,18 @@
 
 // 반응형 디자인
 @media (max-width: 768px) {
+  .profileImageEditor {
+    margin-bottom: 24px;
+  }
+
   .imageContainer {
     width: 100px;
     height: 100px;
+  }
+
+  .profileImage,
+  .imagePlaceholder {
+    border-width: 3px;
   }
 
   .imagePlaceholder {
@@ -109,5 +118,23 @@
     width: 32px;
     height: 32px;
     font-size: 14px;
+    border-width: 2px;
+  }
+}
+
+@media (max-width: 480px) {
+  .imageContainer {
+    width: 90px;
+    height: 90px;
+  }
+
+  .imagePlaceholder {
+    font-size: 36px;
+  }
+
+  .cameraButton {
+    width: 28px;
+    height: 28px;
+    font-size: 12px;
   }
 }

--- a/frontend/src/components/mypage/TermsSection.jsx
+++ b/frontend/src/components/mypage/TermsSection.jsx
@@ -1,0 +1,73 @@
+/**
+ * @개요 약관 보기 섹션 컴포넌트
+ * @작성자 신동준 (sdj3959)
+ * @작성일 2025-10-23
+ * @최종수정일 2025-10-23
+ * @매개변수 {Object} props.termsStatus - 약관 동의 상태 객체 { required: boolean, optional: boolean }
+ * @매개변수 {Function} props.onViewTerms - 약관 보기 버튼 클릭 시 호출되는 함수
+ * @매개변수 {Function} props.onEditTerms - 약관 수정 버튼 클릭 시 호출되는 함수
+ * @반환값 {JSX.Element} 약관 보기 섹션 컴포넌트
+ */
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronRight, faCheck } from '@fortawesome/free-solid-svg-icons';
+import styles from './TermsSection.module.scss';
+
+const TermsSection = ({ termsStatus, onViewTerms, onEditTerms }) => {
+  return (
+    <div className={styles.termsSection}>
+      <div className={styles.divider}></div>
+      
+      <div className={styles.termsList}>
+        {/* 필수 약관 */}
+        <button
+          className={styles.termsButton}
+          onClick={() => onViewTerms('required')}
+          aria-label="서비스 필수 동의 약관 보기"
+        >
+          <div className={styles.termsInfo}>
+            <span className={styles.termsLabel}>서비스 필수 동의 약관</span>
+            <div className={styles.termsStatus}>
+              <FontAwesomeIcon icon={faCheck} className={styles.checkIcon} />
+              <span className={styles.statusText}>동의함</span>
+            </div>
+          </div>
+          <FontAwesomeIcon icon={faChevronRight} className={styles.chevronIcon} />
+        </button>
+
+        {/* 선택 약관 */}
+        <button
+          className={styles.termsButton}
+          onClick={() => onViewTerms('optional')}
+          aria-label="서비스 선택 동의 약관 보기"
+        >
+          <div className={styles.termsInfo}>
+            <span className={styles.termsLabel}>서비스 선택 동의 약관</span>
+            <div className={styles.termsStatus}>
+              {termsStatus.optional ? (
+                <>
+                  <FontAwesomeIcon icon={faCheck} className={styles.checkIcon} />
+                  <span className={styles.statusText}>동의함</span>
+                </>
+              ) : (
+                <span className={styles.statusTextInactive}>동의 안 함</span>
+              )}
+            </div>
+          </div>
+          <FontAwesomeIcon icon={faChevronRight} className={styles.chevronIcon} />
+        </button>
+      </div>
+
+      {/* 약관 동의 수정 버튼 */}
+      <button
+        className={styles.editTermsButton}
+        onClick={onEditTerms}
+        aria-label="약관 동의 수정"
+      >
+        약관 동의 수정
+      </button>
+    </div>
+  );
+};
+
+export default TermsSection;

--- a/frontend/src/components/mypage/TermsSection.jsx
+++ b/frontend/src/components/mypage/TermsSection.jsx
@@ -24,15 +24,16 @@ const TermsSection = ({ termsStatus, onViewTerms, onEditTerms }) => {
           className={styles.termsButton}
           onClick={() => onViewTerms('required')}
           aria-label="서비스 필수 동의 약관 보기"
+          title="서비스 필수 동의 약관 보기"
         >
           <div className={styles.termsInfo}>
             <span className={styles.termsLabel}>서비스 필수 동의 약관</span>
-            <div className={styles.termsStatus}>
-              <FontAwesomeIcon icon={faCheck} className={styles.checkIcon} />
+            <div className={styles.termsStatus} aria-label="동의 상태: 동의함">
+              <FontAwesomeIcon icon={faCheck} className={styles.checkIcon} aria-hidden="true" />
               <span className={styles.statusText}>동의함</span>
             </div>
           </div>
-          <FontAwesomeIcon icon={faChevronRight} className={styles.chevronIcon} />
+          <FontAwesomeIcon icon={faChevronRight} className={styles.chevronIcon} aria-hidden="true" />
         </button>
 
         {/* 선택 약관 */}
@@ -40,13 +41,17 @@ const TermsSection = ({ termsStatus, onViewTerms, onEditTerms }) => {
           className={styles.termsButton}
           onClick={() => onViewTerms('optional')}
           aria-label="서비스 선택 동의 약관 보기"
+          title="서비스 선택 동의 약관 보기"
         >
           <div className={styles.termsInfo}>
             <span className={styles.termsLabel}>서비스 선택 동의 약관</span>
-            <div className={styles.termsStatus}>
+            <div 
+              className={styles.termsStatus} 
+              aria-label={`동의 상태: ${termsStatus.optional ? '동의함' : '동의 안 함'}`}
+            >
               {termsStatus.optional ? (
                 <>
-                  <FontAwesomeIcon icon={faCheck} className={styles.checkIcon} />
+                  <FontAwesomeIcon icon={faCheck} className={styles.checkIcon} aria-hidden="true" />
                   <span className={styles.statusText}>동의함</span>
                 </>
               ) : (
@@ -54,7 +59,7 @@ const TermsSection = ({ termsStatus, onViewTerms, onEditTerms }) => {
               )}
             </div>
           </div>
-          <FontAwesomeIcon icon={faChevronRight} className={styles.chevronIcon} />
+          <FontAwesomeIcon icon={faChevronRight} className={styles.chevronIcon} aria-hidden="true" />
         </button>
       </div>
 
@@ -63,6 +68,7 @@ const TermsSection = ({ termsStatus, onViewTerms, onEditTerms }) => {
         className={styles.editTermsButton}
         onClick={onEditTerms}
         aria-label="약관 동의 수정"
+        title="약관 동의 수정"
       >
         약관 동의 수정
       </button>

--- a/frontend/src/components/mypage/TermsSection.module.scss
+++ b/frontend/src/components/mypage/TermsSection.module.scss
@@ -46,6 +46,10 @@
   }
 
   &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
     outline: 2px solid var(--secondary-color);
     outline-offset: 2px;
   }
@@ -119,6 +123,10 @@
   }
 
   &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
     outline: 2px solid var(--secondary-color);
     outline-offset: 2px;
   }
@@ -138,6 +146,15 @@
 
 // 반응형 디자인
 @media (max-width: 768px) {
+  .divider {
+    margin-bottom: 20px;
+  }
+
+  .termsList {
+    gap: 10px;
+    margin-bottom: 16px;
+  }
+
   .termsButton {
     padding: 12px 16px;
   }
@@ -151,6 +168,10 @@
     font-size: 12px;
   }
 
+  .checkIcon {
+    font-size: 11px;
+  }
+
   .chevronIcon {
     font-size: 13px;
   }
@@ -158,5 +179,25 @@
   .editTermsButton {
     padding: 10px 20px;
     font-size: 14px;
+  }
+}
+
+@media (max-width: 480px) {
+  .termsButton {
+    padding: 10px 14px;
+  }
+
+  .termsLabel {
+    font-size: 13px;
+  }
+
+  .statusText,
+  .statusTextInactive {
+    font-size: 11px;
+  }
+
+  .editTermsButton {
+    padding: 10px 16px;
+    font-size: 13px;
   }
 }

--- a/frontend/src/components/mypage/TermsSection.module.scss
+++ b/frontend/src/components/mypage/TermsSection.module.scss
@@ -1,0 +1,162 @@
+/**
+ * @개요 약관 보기 섹션 컴포넌트 스타일
+ * @작성자 신동준 (sdj3959)
+ * @작성일 2025-10-23
+ * @최종수정일 2025-10-23
+ */
+
+.termsSection {
+  animation: fadeInUp 0.6s ease-out 0.4s both;
+}
+
+.divider {
+  width: 100%;
+  height: 1px;
+  background-color: #e0e0e0;
+  margin-bottom: 24px;
+}
+
+.termsList {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.termsButton {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: transparent;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 14px 20px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  text-align: left;
+
+  &:hover {
+    background-color: var(--background-color);
+    border-color: #bdbdbd;
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+
+  &:focus {
+    outline: 2px solid var(--secondary-color);
+    outline-offset: 2px;
+  }
+}
+
+.termsInfo {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.termsLabel {
+  font-size: 15px;
+  color: var(--text-color);
+  font-weight: 500;
+}
+
+.termsStatus {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.checkIcon {
+  font-size: 12px;
+  color: var(--secondary-color);
+}
+
+.statusText {
+  font-size: 13px;
+  color: var(--secondary-color);
+  font-weight: 500;
+}
+
+.statusTextInactive {
+  font-size: 13px;
+  color: #9e9e9e;
+}
+
+.chevronIcon {
+  font-size: 14px;
+  color: #9e9e9e;
+  transition: transform 0.3s ease;
+
+  .termsButton:hover & {
+    transform: translateX(4px);
+    color: var(--text-color);
+  }
+}
+
+.editTermsButton {
+  width: 100%;
+  background-color: var(--secondary-color);
+  color: var(--white-color);
+  border: none;
+  border-radius: 8px;
+  padding: 12px 24px;
+  font-size: 15px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(144, 202, 249, 0.2);
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 8px rgba(144, 202, 249, 0.3);
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+
+  &:focus {
+    outline: 2px solid var(--secondary-color);
+    outline-offset: 2px;
+  }
+}
+
+// 애니메이션
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// 반응형 디자인
+@media (max-width: 768px) {
+  .termsButton {
+    padding: 12px 16px;
+  }
+
+  .termsLabel {
+    font-size: 14px;
+  }
+
+  .statusText,
+  .statusTextInactive {
+    font-size: 12px;
+  }
+
+  .chevronIcon {
+    font-size: 13px;
+  }
+
+  .editTermsButton {
+    padding: 10px 20px;
+    font-size: 14px;
+  }
+}

--- a/frontend/src/components/ui/AgreementToggle.jsx
+++ b/frontend/src/components/ui/AgreementToggle.jsx
@@ -2,18 +2,19 @@
  * @개요 iOS 스타일 토글 스위치 컴포넌트
  * @작성자 신동준 (sdj3959)
  * @작성일 2025-10-17
- * @최종수정일 2025-10-20
+ * @최종수정일 2025-10-23
  * @매개변수 {boolean} props.checked - 토글 상태
  * @매개변수 {function} props.onChange - 토글 변경 핸들러
  * @매개변수 {string} props.label - 토글 레이블
+ * @매개변수 {boolean} props.disabled - 비활성화 상태
  * @반환값 {JSX.Element} 토글 스위치 컴포넌트
  */
 
 import styles from './AgreementToggle.module.scss';
 
-const AgreementToggle = ({ checked, onChange, label }) => {
+const AgreementToggle = ({ checked, onChange, label, disabled = false }) => {
   return (
-    <div className={styles.agreementToggle}>
+    <div className={`${styles.agreementToggle} ${disabled ? styles.disabled : ''}`}>
       <label className={styles.toggleLabel}>
         <span className={styles.toggleText}>{label}</span>
         <div className={styles.toggleSwitch}>
@@ -21,6 +22,7 @@ const AgreementToggle = ({ checked, onChange, label }) => {
             type="checkbox"
             checked={checked}
             onChange={onChange}
+            disabled={disabled}
           />
           <span className={styles.toggleSlider}></span>
         </div>

--- a/frontend/src/components/ui/AgreementToggle.module.scss
+++ b/frontend/src/components/ui/AgreementToggle.module.scss
@@ -2,7 +2,7 @@
  * @file AgreementToggle 스타일 파일
  * @작성자 신동준 (sdj3959)
  * @작성일 2025-10-17
- * @최종수정일 2025-10-17
+ * @최종수정일 2025-10-23
  */
 
 .agreementToggle {
@@ -63,6 +63,25 @@
           border-radius: 50%;
           box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
         }
+      }
+    }
+  }
+
+  // 비활성화 상태
+  &.disabled {
+    opacity: 0.6;
+    
+    .toggleLabel {
+      cursor: not-allowed;
+    }
+
+    .toggleText {
+      color: #9e9e9e;
+    }
+
+    .toggleSwitch {
+      .toggleSlider {
+        cursor: not-allowed;
       }
     }
   }

--- a/frontend/src/pages/auth/TermsPage.jsx
+++ b/frontend/src/pages/auth/TermsPage.jsx
@@ -6,8 +6,8 @@
  * @반환값 {JSX.Element} 약관 동의 페이지 컴포넌트
  */
 
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import AgreementToggle from '../../components/ui/AgreementToggle';
 import Button from '../../components/ui/Button';
 import Modal from '../../components/ui/Modal';
@@ -16,10 +16,29 @@ import styles from './TermsPage.module.scss';
 
 const TermsPage = () => {
   const navigate = useNavigate();
-  const [agreements, setAgreements] = useState({
+  const location = useLocation();
+  
+  // 마이페이지에서 전달받은 약관 동의 상태
+  const fromMyPage = location.state?.fromMyPage || false;
+  const initialTermsStatus = location.state?.termsStatus || {
     required: false,
     optional: false,
+  };
+
+  const [agreements, setAgreements] = useState({
+    required: initialTermsStatus.required,
+    optional: initialTermsStatus.optional,
   });
+
+  // 마이페이지에서 온 경우 필수 약관은 항상 체크 상태 유지
+  useEffect(() => {
+    if (fromMyPage) {
+      setAgreements(prev => ({
+        ...prev,
+        required: true, // 필수 약관은 항상 true
+      }));
+    }
+  }, [fromMyPage]);
   const [modalState, setModalState] = useState({
     isOpen: false,
     title: '',
@@ -27,6 +46,11 @@ const TermsPage = () => {
   });
 
   const handleToggle = (key) => {
+    // 마이페이지에서 온 경우 필수 약관은 수정 불가
+    if (fromMyPage && key === 'required') {
+      return;
+    }
+    
     setAgreements(prev => ({
       ...prev,
       [key]: !prev[key]
@@ -66,15 +90,28 @@ const TermsPage = () => {
   };
 
   const handleSubmit = () => {
-    // TODO: API 연동이 필요합니다.
-    console.log('약관 동의 제출', agreements);
-    navigate('/popup-close');
+    if (fromMyPage) {
+      // 마이페이지에서 온 경우: 약관 동의 상태 업데이트 후 마이페이지로 돌아가기
+      // TODO: 약관 동의 상태 업데이트 API 연동 필요
+      console.log('약관 동의 수정', agreements);
+      navigate('/mypage');
+    } else {
+      // 최초 가입 시: 팝업 닫기 페이지로 이동
+      // TODO: API 연동이 필요합니다.
+      console.log('약관 동의 제출', agreements);
+      navigate('/popup-close');
+    }
   };
 
   const handleLogout = () => {
     // TODO: 로그아웃 확인 모달 표시
     console.log('로그아웃');
     navigate('/');
+  };
+
+  const handleCancel = () => {
+    // 마이페이지로 돌아가기
+    navigate('/mypage');
   };
 
   const isSubmitEnabled = agreements.required;
@@ -132,14 +169,23 @@ const TermsPage = () => {
               onClick={handleSubmit}
               disabled={!isSubmitEnabled}
             >
-              제출
+              {fromMyPage ? '저장' : '제출'}
             </Button>
-            <Button
-              onClick={handleLogout}
-              variant="secondary"
-            >
-              로그아웃
-            </Button>
+            {fromMyPage ? (
+              <Button
+                onClick={handleCancel}
+                variant="secondary"
+              >
+                취소
+              </Button>
+            ) : (
+              <Button
+                onClick={handleLogout}
+                variant="secondary"
+              >
+                로그아웃
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/frontend/src/pages/auth/TermsPage.jsx
+++ b/frontend/src/pages/auth/TermsPage.jsx
@@ -58,11 +58,20 @@ const TermsPage = () => {
   };
 
   const handleAllAgree = () => {
-    const allChecked = agreements.required && agreements.optional;
-    setAgreements({
-      required: !allChecked,
-      optional: !allChecked,
-    });
+    if (fromMyPage) {
+      // 마이페이지에서 온 경우: 필수 약관은 항상 true, 선택 약관만 토글
+      setAgreements(prev => ({
+        required: true, // 필수 약관은 항상 true
+        optional: !prev.optional,
+      }));
+    } else {
+      // 최초 가입 시: 모든 약관 토글
+      const allChecked = agreements.required && agreements.optional;
+      setAgreements({
+        required: !allChecked,
+        optional: !allChecked,
+      });
+    }
   };
 
   const openTermsModal = (type) => {
@@ -140,6 +149,7 @@ const TermsPage = () => {
                 checked={agreements.required}
                 onChange={() => handleToggle('required')}
                 label="(필수) 서비스 필수 동의 약관"
+                disabled={fromMyPage} // 마이페이지에서 온 경우 비활성화
               />
               <button
                 className={styles.viewTermsButton}

--- a/frontend/src/pages/mypage/MyPage.jsx
+++ b/frontend/src/pages/mypage/MyPage.jsx
@@ -30,7 +30,11 @@ const MyPage = () => {
     isOpen: false,
     title: '',
     content: '',
+    isTermsModal: false, // 약관 모달인지 알림 모달인지 구분
   });
+
+  // 닉네임 업데이트를 위한 key (리렌더링 트리거)
+  const [nicknameKey, setNicknameKey] = useState(0);
 
   const handleViewTerms = (termsType) => {
     if (termsType === 'required') {
@@ -38,14 +42,29 @@ const MyPage = () => {
         isOpen: true,
         title: '서비스 필수 동의 약관',
         content: REQUIRED_TERMS,
+        isTermsModal: true,
       });
     } else {
       setModalState({
         isOpen: true,
         title: '서비스 선택 동의 약관',
         content: OPTIONAL_TERMS,
+        isTermsModal: true,
       });
     }
+  };
+
+  const handleNicknameUpdate = (newNickname) => {
+    // 닉네임 수정 성공 모달 표시
+    setModalState({
+      isOpen: true,
+      title: '닉네임 수정 완료',
+      content: `닉네임이 "${newNickname}"(으)로 변경되었습니다.`,
+      isTermsModal: false,
+    });
+    
+    // 컴포넌트 리렌더링을 위한 key 업데이트
+    setNicknameKey(prev => prev + 1);
   };
 
   const handleEditTerms = () => {
@@ -63,6 +82,7 @@ const MyPage = () => {
       isOpen: false,
       title: '',
       content: '',
+      isTermsModal: false,
     });
   };
 
@@ -74,7 +94,10 @@ const MyPage = () => {
           
           <ProfileImageEditor />
           
-          <NicknameEditor />
+          <NicknameEditor 
+            key={nicknameKey}
+            onNicknameUpdate={handleNicknameUpdate}
+          />
           
           <TermsSection 
             termsStatus={termsStatus}
@@ -89,15 +112,21 @@ const MyPage = () => {
         onClose={closeModal}
         title={modalState.title}
       >
-        <div
-          className={styles.termsContent}
-          dangerouslySetInnerHTML={{
-            __html: modalState.content
-              .replace(/\n/g, '<br />')
-              .replace(/##\s+(.+)/g, '<h2>$1</h2>')
-              .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
-          }}
-        />
+        {modalState.isTermsModal ? (
+          <div
+            className={styles.termsContent}
+            dangerouslySetInnerHTML={{
+              __html: modalState.content
+                .replace(/\n/g, '<br />')
+                .replace(/##\s+(.+)/g, '<h2>$1</h2>')
+                .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+            }}
+          />
+        ) : (
+          <div className={styles.successMessage}>
+            {modalState.content}
+          </div>
+        )}
       </Modal>
     </div>
   );

--- a/frontend/src/pages/mypage/MyPage.jsx
+++ b/frontend/src/pages/mypage/MyPage.jsx
@@ -7,22 +7,98 @@
  */
 
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import ProfileImageEditor from '../../components/mypage/ProfileImageEditor';
+import NicknameEditor from '../../components/mypage/NicknameEditor';
+import TermsSection from '../../components/mypage/TermsSection';
+import Modal from '../../components/ui/Modal';
+import { REQUIRED_TERMS, OPTIONAL_TERMS } from '../../data/termsContent';
 import styles from './MyPage.module.scss';
 
 const MyPage = () => {
+  const navigate = useNavigate();
+  
+  // TODO: 사용자 약관 동의 상태 API 연동 필요
+  // API 호출 예시: const { data } = await getUserTermsStatus();
+  // 응답 형식: { required: true, optional: false }
+  const [termsStatus] = useState({
+    required: true, // 필수 약관은 항상 true (이미 동의한 상태)
+    optional: false, // 선택 약관 동의 상태 (API에서 받아올 값)
+  });
+
+  const [modalState, setModalState] = useState({
+    isOpen: false,
+    title: '',
+    content: '',
+  });
+
+  const handleViewTerms = (termsType) => {
+    if (termsType === 'required') {
+      setModalState({
+        isOpen: true,
+        title: '서비스 필수 동의 약관',
+        content: REQUIRED_TERMS,
+      });
+    } else {
+      setModalState({
+        isOpen: true,
+        title: '서비스 선택 동의 약관',
+        content: OPTIONAL_TERMS,
+      });
+    }
+  };
+
+  const handleEditTerms = () => {
+    // 약관 수정 페이지로 이동하면서 현재 약관 동의 상태 전달
+    navigate('/terms', { 
+      state: { 
+        termsStatus,
+        fromMyPage: true // 마이페이지에서 왔다는 플래그
+      } 
+    });
+  };
+
+  const closeModal = () => {
+    setModalState({
+      isOpen: false,
+      title: '',
+      content: '',
+    });
+  };
+
   return (
     <div className={styles.myPage}>
       <div className={styles.mainContent}>
         <div className={styles.container}>
           <h1 className={styles.pageTitle}>마이페이지</h1>
           
-          {/* TODO: 프로필 이미지 수정 컴포넌트 추가 예정 */}
+          <ProfileImageEditor />
           
-          {/* TODO: 닉네임 수정 컴포넌트 추가 예정 */}
+          <NicknameEditor />
           
-          {/* TODO: 약관 보기 섹션 추가 예정 */}
+          <TermsSection 
+            termsStatus={termsStatus}
+            onViewTerms={handleViewTerms}
+            onEditTerms={handleEditTerms}
+          />
         </div>
       </div>
+
+      <Modal
+        isOpen={modalState.isOpen}
+        onClose={closeModal}
+        title={modalState.title}
+      >
+        <div
+          className={styles.termsContent}
+          dangerouslySetInnerHTML={{
+            __html: modalState.content
+              .replace(/\n/g, '<br />')
+              .replace(/##\s+(.+)/g, '<h2>$1</h2>')
+              .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+          }}
+        />
+      </Modal>
     </div>
   );
 };

--- a/frontend/src/pages/mypage/MyPage.jsx
+++ b/frontend/src/pages/mypage/MyPage.jsx
@@ -1,0 +1,30 @@
+/**
+ * @개요 마이페이지 컴포넌트
+ * @작성자 신동준 (sdj3959)
+ * @작성일 2025-10-23
+ * @최종수정일 2025-10-23
+ * @반환값 {JSX.Element} 마이페이지 컴포넌트
+ */
+
+import { useState } from 'react';
+import styles from './MyPage.module.scss';
+
+const MyPage = () => {
+  return (
+    <div className={styles.myPage}>
+      <div className={styles.mainContent}>
+        <div className={styles.container}>
+          <h1 className={styles.pageTitle}>마이페이지</h1>
+          
+          {/* TODO: 프로필 이미지 수정 컴포넌트 추가 예정 */}
+          
+          {/* TODO: 닉네임 수정 컴포넌트 추가 예정 */}
+          
+          {/* TODO: 약관 보기 섹션 추가 예정 */}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MyPage;

--- a/frontend/src/pages/mypage/MyPage.module.scss
+++ b/frontend/src/pages/mypage/MyPage.module.scss
@@ -7,7 +7,6 @@
 
 .myPage {
   min-height: 100vh;
-  background-color: var(--primary-color);
   display: flex;
   flex-direction: column;
   animation: fadeIn 0.5s ease-in-out;

--- a/frontend/src/pages/mypage/MyPage.module.scss
+++ b/frontend/src/pages/mypage/MyPage.module.scss
@@ -86,11 +86,37 @@
   }
 
   .container {
-    padding: 24px;
+    padding: 24px 20px;
+    border-radius: 8px;
   }
 
   .pageTitle {
     font-size: 20px;
     margin-bottom: 24px;
+  }
+
+  .termsContent {
+    font-size: 13px;
+    line-height: 1.7;
+
+    h2 {
+      font-size: 15px;
+      margin: 16px 0 10px 0;
+    }
+  }
+}
+
+@media (max-width: 480px) {
+  .mainContent {
+    padding: 16px 12px;
+  }
+
+  .container {
+    padding: 20px 16px;
+  }
+
+  .pageTitle {
+    font-size: 18px;
+    margin-bottom: 20px;
   }
 }

--- a/frontend/src/pages/mypage/MyPage.module.scss
+++ b/frontend/src/pages/mypage/MyPage.module.scss
@@ -58,6 +58,14 @@
   }
 }
 
+.successMessage {
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--text-color);
+  text-align: center;
+  padding: 20px;
+}
+
 // 애니메이션
 @keyframes fadeIn {
   from {

--- a/frontend/src/pages/mypage/MyPage.module.scss
+++ b/frontend/src/pages/mypage/MyPage.module.scss
@@ -1,0 +1,77 @@
+/**
+ * @개요 마이페이지 스타일
+ * @작성자 신동준 (sdj3959)
+ * @작성일 2025-10-23
+ * @최종수정일 2025-10-23
+ */
+
+.myPage {
+  min-height: 100vh;
+  background-color: var(--primary-color);
+  display: flex;
+  flex-direction: column;
+  animation: fadeIn 0.5s ease-in-out;
+}
+
+.mainContent {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 40px 20px;
+}
+
+.container {
+  width: 100%;
+  max-width: 600px;
+  background-color: var(--white-color);
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  padding: 40px;
+  animation: scaleIn 0.5s ease-out 0.2s both;
+}
+
+.pageTitle {
+  font-size: 24px;
+  font-weight: bold;
+  color: var(--text-color);
+  margin: 0 0 32px 0;
+  text-align: center;
+}
+
+// 애니메이션
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes scaleIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+// 반응형 디자인
+@media (max-width: 768px) {
+  .mainContent {
+    padding: 20px 16px;
+  }
+
+  .container {
+    padding: 24px;
+  }
+
+  .pageTitle {
+    font-size: 20px;
+    margin-bottom: 24px;
+  }
+}

--- a/frontend/src/pages/mypage/MyPage.module.scss
+++ b/frontend/src/pages/mypage/MyPage.module.scss
@@ -39,6 +39,26 @@
   text-align: center;
 }
 
+.termsContent {
+  font-size: 14px;
+  line-height: 1.8;
+  color: var(--text-color);
+  white-space: pre-wrap;
+  word-break: keep-all;
+
+  h2 {
+    font-size: 16px;
+    font-weight: 600;
+    margin: 20px 0 12px 0;
+    color: var(--text-color);
+  }
+
+  strong {
+    font-weight: 600;
+    color: var(--text-color);
+  }
+}
+
 // 애니메이션
 @keyframes fadeIn {
   from {

--- a/frontend/src/routes/Router.jsx
+++ b/frontend/src/routes/Router.jsx
@@ -2,7 +2,7 @@
  * @개요 애플리케이션 라우팅 설정
  * @작성자 신동준 (sdj3959)
  * @작성일 2025-10-17
- * @최종수정일 2025-10-17
+ * @최종수정일 2025-10-23
  * @반환값 {JSX.Element} 라우터 컴포넌트
  */
 
@@ -12,6 +12,7 @@ import MainLayout from '../layout/MainLayout';
 import LandingPage from '../pages/auth/LandingPage';
 import TermsPage from '../pages/auth/TermsPage';
 import MainPage from '../pages/main/MainPage';
+import MyPage from '../pages/mypage/MyPage';
 import GameRoom from '../pages/GameRoom';
 import QuizWaitingRoom from '../pages/quiz/QuizWaitingRoom';
 import QuizGamePage from '../pages/quiz/QuizGamePage';
@@ -53,6 +54,11 @@ const Router = () => {
         <Route path="/main" element={
           <MainLayout>
             <MainPage />
+          </MainLayout>
+        } />
+        <Route path="/mypage" element={
+          <MainLayout>
+            <MyPage />
           </MainLayout>
         } />
         <Route path="/gameroom" element={


### PR DESCRIPTION
## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요. (선택된 항목은 자동 라벨링됩니다)
- [x] 기능 (Feature)
- [ ] 버그 수정 (Bugfix)
- [x] 기능 개선 (Enhancement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
SignBell 서비스의 마이페이지 UI/UX를 구현했습니다. 사용자가 자신의 프로필 정보를 확인하고 수정할 수 있는 페이지로, 메인 페이지와 동일한 디자인 베이스를 유지하면서 iOS 스타일과 인스타그램의 심플한 디자인을 적용했습니다.

프로필 이미지 수정, 닉네임 수정, 약관 동의 상태 확인 및 수정 기능을 제공하며, 메인 페이지의 헤더 버튼 또는 프로필 카드의 수정 아이콘을 통해 진입할 수 있습니다. 모든 기능은 실시간 유효성 검사와 함께 제공되며, 접근성과 반응형 디자인을 고려하여 구현했습니다.

---

## 관련 이슈 (Related Issue)
> 이 PR과 관련된 이슈 번호를 작성해주세요.

- Closes #80 

---

## 변경 사항 (Changes)

### 1. 마이페이지 라우팅 및 기본 구조
- `/mypage` 경로 추가 및 MyPage 컴포넌트 생성
- 중앙 정렬 카드 스타일 레이아웃 (최대 너비 600px)
- 페이지 진입 애니메이션 (fadeIn) 적용
- 메인 컨테이너 카드 스타일링 (box-shadow, border-radius)

### 2. 프로필 이미지 수정 컴포넌트
- **ProfileImageEditor** 컴포넌트 생성
- 원형 프로필 이미지 (120px, Secondary Color border)
- 플레이스홀더 지원 (Font Awesome faUser 아이콘)
- 우측 하단 카메라 버튼 (Accent Color)
- 파일 선택 다이얼로그 연동
- 이미지 미리보기 기능 (FileReader API)
- 파일 형식 검증 (JPG, PNG, GIF)
- 파일 크기 검증 (5MB 이하)
- 에러 처리 및 input 초기화

### 3. 닉네임 수정 컴포넌트
- **NicknameEditor** 컴포넌트 생성
- 입력 필드 + 수정 버튼 (가로 배치, flex)
- 실시간 유효성 검사
  - 2-10자 길이 제한
  - 한글, 영문, 숫자만 허용
  - 특수문자 필터링
- 에러 메시지 표시 (role="alert")
- Enter 키로 제출 가능
- 원본과 비교하여 수정 버튼 활성화
- 수정 성공 시 모달 표시
- 컴포넌트 리렌더링 (key 업데이트)

### 4. 약관 보기 및 수정 섹션
- **TermsSection** 컴포넌트 생성
- 필수/선택 약관 버튼 2개 배치
- 약관 동의 상태 표시 (체크 아이콘)
  - 필수 약관: "동의함" 디폴트
  - 선택 약관: API 연동 준비 (동의함/동의 안 함)
- 약관 내용 모달로 표시 (기존 Modal 컴포넌트 재사용)
- "약관 동의 수정" 버튼 추가
- /terms 페이지로 상태 전달 (navigate state)

### 5. 약관 수정 페이지 개선
- **TermsPage** 컴포넌트 수정
- fromMyPage 플래그로 마이페이지 진입 구분
- 필수 약관 비활성화 (disabled)
- 전체 동의 버튼 로직 개선
  - 마이페이지에서 온 경우: 필수는 항상 true, 선택만 토글
  - 최초 가입 시: 모든 약관 토글 (기존 동작 유지)
- 저장/취소 버튼 표시 (마이페이지에서 온 경우)
- **AgreementToggle** 컴포넌트에 disabled 속성 추가
- 비활성화 상태 스타일 추가 (opacity, cursor)

### 6. 헤더 컴포넌트 마이페이지 대응
- 헤더 마이페이지 버튼 클릭 시 /mypage로 이동
- 마이페이지에서 뒤로가기 버튼 표시 (faArrowLeft)
- 로고 클릭 시 페이지별 동작 구분
  - 메인 페이지: 새로고침
  - 마이페이지: 메인 페이지로 이동
  - 기타: 랜딩 페이지로 이동
- 프로필 카드 수정 아이콘 마이페이지 연결

### 7. 반응형 디자인
- 태블릿(768px) 브레이크포인트 추가
- 모바일(480px) 브레이크포인트 추가
- 프로필 이미지 크기 조정 (120px → 100px → 90px)
- 닉네임 입력 필드 세로 레이아웃 (모바일)
- 약관 버튼 간격 및 폰트 크기 조정
- 컨테이너 padding 및 border-radius 최적화
- 터치 영역 유지하면서 공간 효율성 개선

### 8. 접근성 및 UX 개선
- 모든 버튼에 title 속성 추가 (툴팁)
- 아이콘에 aria-hidden 추가 (스크린 리더 중복 방지)
- 약관 동의 상태에 aria-label 추가
- Enter 키로 닉네임 제출 가능
- 파일 검증 실패 시 input 초기화
- 포커스 스타일 개선 (focus-visible 적용)
- 키보드 네비게이션 최적화 (tabIndex)

### 9. UI 버그 수정
- 마이페이지 배경색 제거 (카드만 흰색)
- 프로필/닉네임 수정 버튼 포커스 버그 수정
- 닉네임 수정 버튼을 입력 필드 오른쪽으로 이동
- 닉네임 수정 시 카드 크기 변화 방지 (min-height 설정)
- 닉네임 검증 로직 개선 (원본과 비교)

### 10. 코드 품질
- 모든 컴포넌트에 한글 JavaDoc 주석 추가
- 작성자, 작성일, 최종수정일 명시
- API 연동 필요 부분에 TODO 주석 추가
- 컴포넌트 단위 SCSS 파일 분리
- Props 타입 명시 및 설명 추가

---

## 스크린샷 (Screenshots)

### 촬영 필요한 스크린샷 목록:

#### 1. 마이페이지 전체
- [ ] **마이페이지 전체 화면**
  - URL: `http://localhost:5173/mypage`
  - 프로필 이미지 + 닉네임 + 약관 섹션
<img width="1900" height="918" alt="image" src="https://github.com/user-attachments/assets/523c8fba-5045-46c4-a30a-e0f1e7fe9a90" />


#### 2. 프로필 이미지
- [ ] **프로필 이미지 섹션**
  - 원형 이미지 (120px)
  - 카메라 버튼 (Accent Color)
<img width="209" height="171" alt="image" src="https://github.com/user-attachments/assets/5a32b1c4-abcf-4b40-acd8-2286aef23543" />

#### 3. 닉네임 수정
- [ ] **닉네임 입력 필드**
  - 입력 필드 + 수정 버튼 (가로 배치)
<img width="315" height="111" alt="image" src="https://github.com/user-attachments/assets/57ee3cbb-5dfc-4667-8a74-519407d5bdf1" />

  
- [ ] **닉네임 포커스 상태**
  - 입력 필드 포커스 시 border 색상 변경
  - box-shadow 효과
<img width="360" height="101" alt="image" src="https://github.com/user-attachments/assets/86daee00-907b-434c-87b0-94c974ff46ab" />


- [ ] **닉네임 유효성 검사 에러**
  - 1자 입력: "닉네임은 2자 이상이어야 합니다."
  - 특수문자 입력: "닉네임은 한글, 영문, 숫자만 사용 가능합니다."
  - 11자 입력: "닉네임은 10자 이하여야 합니다."
<img width="318" height="126" alt="image" src="https://github.com/user-attachments/assets/b5aae671-be2e-4eda-bad0-23b0e10351b7" />


- [ ] **닉네임 수정 성공 모달**
  - 수정 완료 모달 표시
  - 성공 메시지 확인
<img width="953" height="757" alt="image" src="https://github.com/user-attachments/assets/014e5dc3-6bdf-48ef-b362-2afa30c5c762" />


#### 4. 약관 섹션
- [ ] **약관 버튼 목록**
  - 필수/선택 약관 버튼 2개
  - 구분선 표시
<img width="321" height="284" alt="image" src="https://github.com/user-attachments/assets/3a840f34-c283-4768-8b11-d40737885c8f" />

  
- [ ] **약관 동의 상태**
  - 필수 약관: 체크 아이콘 + "동의함"
  - 선택 약관: "동의함" 또는 "동의 안 함"
<img width="76" height="25" alt="image" src="https://github.com/user-attachments/assets/7c64a5f7-25ec-4a1c-b44c-523d6a65b214" />
<img width="74" height="26" alt="image" src="https://github.com/user-attachments/assets/04bcc693-a2a1-4387-b1cf-0ba736f3cfb5" />


- [ ] **약관 버튼 호버 상태**
  - 배경색 변경
  - 화살표 이동 효과
<img width="337" height="187" alt="image" src="https://github.com/user-attachments/assets/ab0d13db-8ccc-4610-88fa-e11aaf592208" />


- [ ] **필수 약관 모달**
  - 필수 약관 내용 모달 표시
  - 스크롤 가능
<img width="1329" height="909" alt="image" src="https://github.com/user-attachments/assets/44015075-32cf-4e99-a939-73b366277bf9" />


- [ ] **선택 약관 모달**
  - 선택 약관 내용 모달 표시
<img width="1243" height="874" alt="image" src="https://github.com/user-attachments/assets/d5dc4c02-fc9c-4d75-b98c-3e157eaddb8a" />


- [ ] **약관 수정 페이지**
  - /terms 페이지로 이동
  - 필수 약관 비활성화 (opacity 0.6)
  - 전체 동의 버튼 클릭 시 선택만 토글
  - 저장/취소 버튼 표시
<img width="1901" height="906" alt="image" src="https://github.com/user-attachments/assets/c49cbcb3-443b-4ecc-b566-6d6871d4e7f1" />


#### 5. 헤더
- [ ] **헤더 뒤로가기 버튼**
  - 마이페이지에서 뒤로가기 버튼 표시
  - Secondary Color 배경
<img width="273" height="71" alt="image" src="https://github.com/user-attachments/assets/9de9bf97-5859-4e66-8e42-e65a0feb9566" />


- [ ] **메인 페이지 헤더**
  - 마이페이지 버튼 표시
  - 로그아웃 버튼 표시
<img width="1877" height="195" alt="image" src="https://github.com/user-attachments/assets/4cb5fbba-1873-460e-bdcf-757060ab7a65" />


#### 6. 반응형
- [ ] **태블릿 뷰 (768px)**
  - 컨테이너 padding 조정
  - 프로필 이미지 100px
<img width="653" height="769" alt="image" src="https://github.com/user-attachments/assets/41ffec13-5b43-4527-a285-0f12640f03e1" />

  
- [ ] **모바일 뷰 (480px)**
  - 닉네임 입력 필드 세로 배치
  - 수정 버튼 전체 너비
  - 프로필 이미지 90px
<img width="638" height="913" alt="image" src="https://github.com/user-attachments/assets/f6f68829-0333-4a57-ac54-bbafffbff5c4" />

---

## 테스트 방법 (Test Steps)

### 환경 설정
```bash
cd frontend
npm install
npm run dev
```
브라우저에서 `http://localhost:5173` 접속

### 1. 페이지 진입 테스트
1. 메인 페이지에서 헤더의 마이페이지 버튼 클릭
2. URL이 `/mypage`로 변경되는지 확인
3. 마이페이지가 렌더링되는지 확인
4. 페이지 진입 애니메이션 (fadeIn) 확인
5. 프로필 카드 수정 아이콘 클릭으로도 진입 가능한지 확인

### 2. 프로필 이미지 수정 테스트
1. 프로필 이미지 플레이스홀더 표시 확인 (faUser 아이콘)
2. 카메라 버튼 클릭
3. 파일 선택 다이얼로그 열림 확인
4. JPG 이미지 선택
   - 미리보기 업데이트 확인
   - 콘솔에 "이미지 선택됨" 로그 확인
5. 카메라 버튼 다시 클릭
6. 6MB 이미지 선택
   - "이미지 크기는 5MB 이하여야 합니다." 알림 확인
7. TXT 파일 선택
   - "JPG, PNG, GIF 형식의 이미지만 업로드 가능합니다." 알림 확인

### 3. 닉네임 수정 테스트
1. 현재 닉네임 "사용자" 표시 확인
2. 입력 필드 클릭
   - 포커스 효과 확인 (border-color 변경, box-shadow)
3. "홍" 입력
   - "닉네임은 2자 이상이어야 합니다." 에러 메시지 확인
   - 수정 버튼 비활성화 확인
4. "홍길동" 입력
   - 에러 메시지 사라짐 확인
   - 수정 버튼 활성화 확인
5. "홍길동!" 입력
   - "닉네임은 한글, 영문, 숫자만 사용 가능합니다." 에러 메시지 확인
6. "홍길동123456789" 입력 (11자)
   - "닉네임은 10자 이하여야 합니다." 에러 메시지 확인
7. "홍길동" 입력 후 수정 버튼 클릭
   - 성공 모달 표시 확인
   - "닉네임이 "홍길동"(으)로 변경되었습니다." 메시지 확인
8. 모달 닫기
   - 컴포넌트 리렌더링 확인
9. "홍길동" 입력 (원본과 동일)
   - 수정 버튼 비활성화 확인
10. Enter 키로 제출 테스트
    - "테스트" 입력 후 Enter
    - 성공 모달 표시 확인

### 4. 약관 섹션 테스트
1. 약관 버튼 2개 표시 확인
2. 필수 약관 상태 확인
   - 체크 아이콘 표시
   - "동의함" 텍스트 표시
3. 선택 약관 상태 확인
   - "동의 안 함" 텍스트 표시 (초기 상태)
4. "서비스 필수 동의 약관" 버튼 클릭
   - 모달 열림 확인
   - 필수 약관 내용 표시 확인
   - 스크롤 가능 확인
5. 모달 X 버튼 클릭
   - 모달 닫힘 확인
6. "서비스 선택 동의 약관" 버튼 클릭
   - 모달 열림 확인
   - 선택 약관 내용 표시 확인
7. 오버레이 클릭
   - 모달 닫힘 확인
8. "약관 동의 수정" 버튼 클릭
   - URL이 `/terms`로 변경 확인
   - 필수 약관 체크되고 비활성화 확인 (opacity 0.6)
   - 선택 약관 체크 해제 상태 확인
9. 필수 약관 토글 클릭
   - 동작하지 않음 확인 (비활성화)
10. 전체 동의 버튼 클릭
    - 선택 약관만 체크됨 확인
    - 필수 약관은 항상 체크 상태 유지 확인
11. 저장 버튼 클릭
    - URL이 `/mypage`로 변경 확인
12. 취소 버튼 클릭
    - URL이 `/mypage`로 변경 확인

### 5. 헤더 테스트
1. 마이페이지에서 헤더 확인
   - 뒤로가기 버튼 표시 확인
   - 마이페이지/로그아웃 버튼 미표시 확인
2. 뒤로가기 버튼 클릭
   - URL이 `/main`으로 변경 확인
3. 로고 클릭
   - URL이 `/main`으로 변경 확인
4. 메인 페이지에서 헤더 확인
   - 마이페이지 버튼 표시 확인
   - 로그아웃 버튼 표시 확인

### 6. 반응형 디자인 테스트
1. 브라우저 개발자 도구 열기 (F12)
2. 디바이스 툴바 활성화 (Ctrl+Shift+M)
3. 데스크톱 (1200px)
   - 컨테이너 최대 너비 600px 확인
   - 프로필 이미지 120px 확인
4. 태블릿 (768px)
   - 컨테이너 padding 조정 확인
   - 프로필 이미지 100px 확인
5. 모바일 (480px)
   - 닉네임 입력 필드 세로 배치 확인
   - 수정 버튼 전체 너비 확인
   - 프로필 이미지 90px 확인

### 7. 접근성 테스트
1. Tab 키로 모든 인터랙티브 요소 접근
   - 카메라 버튼 → 닉네임 입력 → 수정 버튼 → 약관 버튼들 → 약관 수정 버튼
2. Enter 키로 버튼 클릭 가능 확인
3. 포커스 상태 시각화 확인 (outline)
4. 스크린 리더 테스트 (선택사항)
   - aria-label 읽기 확인
   - role="alert" 에러 메시지 읽기 확인

### 8. 브라우저 호환성 테스트
- Chrome: 정상 동작 확인
- Safari: 정상 동작 확인
- Firefox: 정상 동작 확인

### 9. 콘솔 에러 확인
1. 브라우저 개발자 도구 콘솔 탭 열기
2. 모든 페이지 이동 및 기능 테스트 수행
3. 콘솔에 에러가 없는지 확인
4. TODO 주석 관련 로그만 표시되는지 확인

---

## 셀프 체크리스트 (Self-Checklist)
> 리뷰 요청 전, 아래 항목을 확인해주세요.
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [ ] CI/CD 파이프라인이 통과했습니다.

### 추가 체크리스트
- [x] 모든 컴포넌트에 한글 JavaDoc 주석 작성
- [x] 색상 가이드 준수
- [x] 커밋 메시지 규칙 준수
- [x] API 연동 필요 부분에 TODO 주석 추가
- [x] 반응형 디자인 적용 (768px, 480px)
- [x] 브라우저 콘솔 에러 없음
- [x] 모든 페이지 이동 정상 동작
- [x] 유효성 검사 정상 동작
- [x] 접근성 속성 추가 (aria-label, role, title)
- [x] 키보드 네비게이션 지원
- [x] 포커스 스타일 개선 (focus-visible)

---

## 리뷰어에게 (To Reviewers)

### 집중 검토 요청 사항
1. **UI/UX 디자인 검토**
   - iOS 스타일과 인스타그램 심플함의 조화
   - 메인 페이지와의 디자인 일관성
   - 카드 스타일 레이아웃의 적절성
   - 버튼 배치 및 간격의 자연스러움

2. **유효성 검사 로직 검토**
   - 닉네임 검증 로직의 정확성
   - 에러 메시지의 명확성
   - 실시간 검증의 사용자 경험
   - 원본과 비교하여 버튼 활성화 로직

3. **약관 수정 플로우 검토**
   - 마이페이지 → /terms 페이지 상태 전달
   - 필수 약관 비활성화 처리
   - 전체 동의 버튼 로직 개선
   - 저장/취소 버튼 동작

4. **접근성 검토**
   - aria-label, role, title 속성의 적절성
   - 키보드 네비게이션 지원
   - 포커스 스타일의 명확성
   - 스크린 리더 호환성

5. **반응형 디자인 검토**
   - 모바일, 태블릿, 데스크톱 레이아웃
   - 터치 영역의 적절성
   - 폰트 크기 및 간격 조정

6. **코드 구조 검토**
   - 컴포넌트 분리의 적절성
   - 부모-자식 컴포넌트 간 통신
   - 상태 관리 방식
   - 재사용 가능한 컴포넌트 설계

### 참고 사항
- 모든 API 호출 부분에 TODO 주석을 남겨두었습니다.
- 프로필 이미지 및 닉네임은 하드코딩되어 있으며, 추후 API 연동 시 동적으로 표시됩니다.
- 약관 동의 상태는 초기값으로 설정되어 있으며, 추후 API 연동 시 실제 데이터로 대체됩니다.
- 메인 페이지와 동일한 디자인 베이스를 유지하면서 마이페이지만의 특성을 반영했습니다.

### 테스트 환경
- Node.js: v20.x
- npm: v10.x
- 브라우저: Chrome 최신 버전

---

## 브랜치 정보 (Branch Information)
- **작업 브랜치**: `feat/my-page-ui`
- **머지 대상**: `dev`
- **작업 기간**: 2025-10-23
- **담당자**: sdj3959
