### PR TITLE
[Enhancement]: Zustand 연동으로 사용자 인증 및 상태 관리 로직 개선 (#88)

### DIFF
--- a/frontend/src/pages/quiz/QuizWaitingRoom.jsx
+++ b/frontend/src/pages/quiz/QuizWaitingRoom.jsx
@@ -11,12 +11,18 @@ import { useParams, useNavigate } from 'react-router-dom';
 import useWebcam from '../../hooks/useWebcam';
 import styles from './QuizWaitingRoom.module.scss';
 import websocketService from '../../services/websocket/websocketService.js';
+import {useAuthStore} from '../../store/auth/authStore.js';
 
 const QuizWaitingRoom = () => {
   const { roomId } = useParams();
   const navigate = useNavigate();
   const [showExitModal, setShowExitModal] = useState(false);
-  const [myUserId, setMyUserId] = useState(null);
+  // const [myUserId, setMyUserId] = useState(null);
+
+  // Zustand에서 사용자 정보 가져오기
+  const { user, isAuthenticated, hasCheckedAuth } = useAuthStore();
+  const myUserId = user?.userId; // ✅ 직접 가져오기
+
   const [allReady, setAllReady] = useState(false);
 
   // 웹캠 관리
@@ -56,6 +62,24 @@ const QuizWaitingRoom = () => {
 
   // Janus 서버 URL
   const JANUS_SERVER = import.meta.env.VITE_JANUS_SERVER || 'https://janus.jsflux.co.kr/janus';
+
+  // 인증 체크 - hasCheckedAuth가 true일 때만 체크
+  useEffect(() => {
+
+    // localStorage 복원이 완료될 때까지 대기
+    if (!hasCheckedAuth) {
+      console.log('⏳ 인증 상태 확인 중...');
+      return;
+    }
+
+    // 인증 확인 후 로그인 안 되어 있으면 리다이렉트
+    if (!isAuthenticated || !myUserId) {
+      alert('로그인이 필요합니다.');
+      navigate('/main'); // 또는 '/main'
+    } else {
+      console.log('✅ 인증 확인:', myUserId);
+    }
+  }, [hasCheckedAuth, isAuthenticated, myUserId, navigate]);
 
   // WebSocket 연결
   useEffect(() => {
@@ -347,8 +371,8 @@ const QuizWaitingRoom = () => {
 
       // TODO: 실제 로그인한 사용자 ID 가져오기
       // 임시로 마지막 참가자를 "나"로 설정 (방금 입장한 사람)
-      const myId = roomData.participants[roomData.participants.length - 1].userId;
-      setMyUserId(myId); // state에 저장
+      // const myId = roomData.participants[roomData.participants.length - 1].userId;
+      // setMyUserId(myId); // state에 저장
 
       // 참가자 목록 업데이트
       const formattedParticipants = roomData.participants.map(p => ({
@@ -357,7 +381,7 @@ const QuizWaitingRoom = () => {
         nickname: p.nickname,
         profileImageUrl: p.profileImageUrl,
         score: 0, // TODO: 실제 점수는 나중에
-        isMe: p.userId === myId, // 나인지 확인
+        isMe: p.userId === myUserId, // Zustand에서 가져온 myUserId 사용
         isHost: p.host,
         isReady: p.ready,
         webcamStatus: 'off'


### PR DESCRIPTION
# Pull Request

## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요. (선택된 항목은 자동 라벨링됩니다)
- [ ] 기능 (Feature)
- [ ] 버그 수정 (Bugfix)
- [x] 기능 개선 (Enhancement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
퀴즈 대기방에서 실제 로그인한 사용자 ID를 Zustand의 `useAuthStore`에서 가져오도록 개선했습니다. 기존에는 임시로 마지막 참가자를 본인으로 설정하는 방식을 사용했으나, 이제 전역 상태 관리를 통해 정확한 사용자 식별이 가능합니다.

**핵심 개선 사항:**
- ✅ Zustand 기반 사용자 인증 상태 관리 도입
- ✅ localStorage persist를 통한 새로고침 후에도 인증 상태 유지
- ✅ 임시 사용자 ID 설정 로직 제거 및 실제 로그인 정보 활용
- ✅ 인증되지 않은 사용자 접근 차단 로직 추가

---

## 관련 이슈 (Related Issue)
- Closes #88

---

## 변경 사항 (Changes)

### 1. **Zustand authStore 연동**
- `useAuthStore`를 import하여 전역 인증 상태 사용
- `user`, `isAuthenticated`, `hasCheckedAuth` 상태 가져오기
- 기존 `useState`로 관리하던 `myUserId` 제거

```javascript
// 변경 전
const [myUserId, setMyUserId] = useState(null);

// 변경 후
import { useAuthStore } from '../../store/auth/authStore.js';
const { user, isAuthenticated, hasCheckedAuth } = useAuthStore();
const myUserId = user?.userId;
```

### 2. **인증 체크 로직 추가**
- localStorage 복원 완료 후 인증 상태 확인
- 비로그인 사용자는 `/main` 페이지로 리다이렉트
- `hasCheckedAuth` 플래그를 활용하여 초기화 완료 확인

```javascript
useEffect(() => {
  // localStorage 복원이 완료될 때까지 대기
  if (!hasCheckedAuth) {
    console.log('⏳ 인증 상태 확인 중...');
    return;
  }

  // 인증 확인 후 로그인 안 되어 있으면 리다이렉트
  if (!isAuthenticated || !myUserId) {
    alert('로그인이 필요합니다.');
    navigate('/main');
  } else {
    console.log('✅ 인증 확인:', myUserId);
  }
}, [hasCheckedAuth, isAuthenticated, myUserId, navigate]);
```

### 3. **임시 사용자 ID 설정 로직 제거**
- `handleRoomJoin` 함수에서 마지막 참가자를 임시로 본인으로 설정하던 코드 주석 처리
- Zustand에서 가져온 `myUserId`를 직접 사용

```javascript
// 제거된 코드 (주석 처리)
// const myId = roomData.participants[roomData.participants.length - 1].userId;
// setMyUserId(myId);
```

### 4. **WebSocket 및 참가자 로직 개선**
- 참가자 목록 생성 시 Zustand 기반 `myUserId` 사용
- `isMe` 판별 로직에 정확한 사용자 ID 적용
- Janus WebRTC 연결 시 올바른 userId 전달 보장

---

## 스크린샷 (Screenshots) (Optional)

### authStore 상태 (localStorage persist)
<img width="1040" height="943" alt="image" src="https://github.com/user-attachments/assets/056808f5-5508-421c-bfd0-2f6268d44923" />

위 이미지에서 확인할 수 있듯이, `userId: 1`, `nickname: "김코즈"` 등의 사용자 정보가 전역 상태로 관리되고 있습니다.

### 게임 대기방 로그
<img width="1040" height="854" alt="image" src="https://github.com/user-attachments/assets/f33e0a20-b111-40ba-a101-f9ab7c76daf4" />


---

## 테스트 방법 (Test Steps)

### 1. 로그인 후 대기방 입장 테스트
1. 애플리케이션에 로그인합니다.
2. 퀴즈 대기방에 입장합니다.
3. 참가자 목록에서 본인의 닉네임 옆에 "(나)" 표시가 정확하게 나타나는지 확인합니다.
4. 콘솔에서 `✅ 인증 확인: [사용자ID]` 로그가 출력되는지 확인합니다.

### 2. 새로고침 후 인증 상태 유지 테스트
1. 퀴즈 대기방에 입장한 상태에서 페이지를 새로고침(F5)합니다.
2. 새로고침 후에도 "로그인이 필요합니다" 알림이 뜨지 않는지 확인합니다.
3. 본인 정보가 그대로 유지되는지 확인합니다.
4. 콘솔에서 `⏳ 인증 상태 확인 중...` → `✅ 인증 확인: [사용자ID]` 순서로 로그가 출력되는지 확인합니다.

### 3. 비로그인 사용자 접근 차단 테스트
1. 로그아웃 상태에서 퀴즈 대기방 URL로 직접 접근합니다.
2. "로그인이 필요합니다" 알림이 표시되는지 확인합니다.
3. `/main` 페이지로 리다이렉트되는지 확인합니다.

### 4. WebRTC 연결 테스트
1. 두 개의 브라우저(또는 시크릿 모드)로 각각 다른 계정으로 로그인합니다.
2. 같은 퀴즈 대기방에 입장합니다.
3. 웹캠을 켜고 상대방의 영상이 정상적으로 표시되는지 확인합니다.
4. 콘솔에서 Janus 연결 시 올바른 userId가 전달되는지 확인합니다.

---

## 셀프 체크리스트 (Self-Checklist)
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [ ] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)

### 중점 검토 사항
1. **인증 로직 검증**: `hasCheckedAuth` 플래그를 활용한 초기화 완료 대기 로직이 적절한지 확인해주세요.
2. **새로고침 시나리오**: localStorage persist가 복원되기 전에 리다이렉트되지 않는지 확인해주세요.
3. **WebSocket 연동**: 기존 WebSocket 이벤트 핸들러(`handleRoomJoin`, `handleParticipantEvent`)에서 Zustand 기반 `myUserId`가 정상적으로 동작하는지 확인해주세요.
4. **Janus WebRTC**: `display: String(myUserId)` 부분에서 정확한 userId가 전달되는지 확인해주세요.
