### PR TITLE
[Feat]: 퀴즈 대기방 연결 해제 및 예외 상황 처리 (#84)

### DIFF
--- a/frontend/src/pages/quiz/QuizWaitingRoom.jsx
+++ b/frontend/src/pages/quiz/QuizWaitingRoom.jsx
@@ -12,11 +12,13 @@ import useWebcam from '../../hooks/useWebcam';
 import styles from './QuizWaitingRoom.module.scss';
 import websocketService from '../../services/websocket/websocketService.js';
 import {useAuthStore} from '../../store/auth/authStore.js';
+import AlertModal from '../../components/ui/AlertModal.jsx';
 
 const QuizWaitingRoom = () => {
   const { roomId } = useParams();
   const navigate = useNavigate();
   const [showExitModal, setShowExitModal] = useState(false);
+  const [showRoomClosedAlert, setShowRoomClosedAlert] = useState(false);
   // const [myUserId, setMyUserId] = useState(null);
 
   // Zustand에서 사용자 정보 가져오기
@@ -81,12 +83,20 @@ const QuizWaitingRoom = () => {
     }
   }, [hasCheckedAuth, isAuthenticated, myUserId, navigate]);
 
+  // 방 종료 이벤트 핸들러
+  const handleRoomClosed = (data) => {
+    console.log('📥 방 종료 알림:', data);
+    // AlertModal 표시
+    setShowRoomClosedAlert(true);
+  };
+
   // WebSocket 연결
   useEffect(() => {
     const initWebSocket = async () => {
       try {
         websocketService.on('room:join', handleRoomJoin);
         websocketService.on('participant', handleParticipantEvent);
+        websocketService.on('room:closed', handleRoomClosed);
         websocketService.on('error', handleError);
 
         await websocketService.connect();
@@ -108,6 +118,7 @@ const QuizWaitingRoom = () => {
     return () => {
       websocketService.off('room:join', handleRoomJoin);
       websocketService.off('participant', handleParticipantEvent);
+      websocketService.off('room:closed', handleRoomClosed);
       websocketService.off('error', handleError);
     };
   }, [roomId]);
@@ -448,9 +459,8 @@ const QuizWaitingRoom = () => {
       case 'PARTICIPANT_LEFT':
         console.log('👋 참가자 퇴장:', eventData.participant);
         if (eventData.roomClosed) {
-          alert('방장이 나가서 방이 종료되었습니다.');
-          websocketService.disconnect();
-          navigate('/main');
+          // 방장이 나가서 방이 종료됨 - AlertModal 표시
+          setShowRoomClosedAlert(true);
           return;
         }
         setParticipants(prev =>
@@ -483,6 +493,12 @@ const QuizWaitingRoom = () => {
           );
           break;
         }
+
+      case 'ROOM_CLOSED':
+        console.log('🚪 방 종료:', eventData);
+        // 방장이 나가서 방이 종료됨 - AlertModal 표시
+        setShowRoomClosedAlert(true);
+        break;
 
       default:
         console.log('알 수 없는 이벤트:', eventData.eventType);
@@ -562,14 +578,65 @@ const QuizWaitingRoom = () => {
     navigate(`/quiz/game/${roomId}`);
   };
 
-  // 방 나가기
+  // 방 나가기 공통 처리 함수
+  const cleanupAndExit = async () => {
+    try {
+      console.log('🚪 방 나가기 처리 시작');
+
+      // 1. Janus WebRTC 정리
+      if (janusRef.current) {
+        try {
+          janusRef.current.destroy();
+          janusRef.current = null;
+          pluginHandleRef.current = null;
+          remoteFeedsRef.current = {};
+          userIdToFeedIdRef.current = {};
+          setIsJanusConnected(false);
+          console.log('✅ Janus 정리 완료');
+        } catch (error) {
+          console.error('Janus 정리 실패:', error);
+        }
+      }
+
+      // 2. 웹캠 정리
+      if (stream) {
+        try {
+          stream.getTracks().forEach((track) => track.stop());
+          console.log('✅ 웹캠 정리 완료');
+        } catch (error) {
+          console.error('웹캠 정리 실패:', error);
+        }
+      }
+
+      // 3. WebSocket 연결 해제
+      // ⚠️ 중요: 연결 해제 시 서버의 WebSocketEventsListener가 자동 감지
+      // → DB 정리 + 다른 참가자에게 브로드캐스팅 자동 처리
+      websocketService.disconnect();
+      console.log('✅ WebSocket 연결 해제 완료 (서버가 자동으로 퇴장 처리)');
+
+      // 4. 메인 페이지로 이동
+      navigate('/main');
+    } catch (error) {
+      console.error('❌ 방 나가기 실패:', error);
+      // 에러가 있어도 강제로 메인으로 이동
+      // 서버는 WebSocket 연결 끊김을 감지하여 자동 처리
+      navigate('/main');
+    }
+  };
+
+  // 나가기 버튼 클릭
   const handleExit = () => {
     setShowExitModal(true);
   };
 
+  // 나가기 확인
   const confirmExit = () => {
-    // TODO: WebSocket으로 방 나가기 전송
-    navigate('/main');
+    cleanupAndExit();
+  };
+
+  // 방 종료 알림 닫기 (메인으로 이동)
+  const handleRoomClosedAlertClose = () => {
+    cleanupAndExit();
   };
 
   // 웹캠 상태 아이콘 색상
@@ -784,6 +851,15 @@ const QuizWaitingRoom = () => {
           </div>
         </>
       )}
+
+      {/* 방 종료 알림 모달 */}
+      <AlertModal
+        isOpen={showRoomClosedAlert}
+        onClose={handleRoomClosedAlertClose}
+        title="방 종료"
+        message="방장이 나가서 방이 종료되었습니다."
+        type="warning"
+      />
     </div>
   );
 };

--- a/frontend/src/pages/quiz/QuizWaitingRoom.jsx
+++ b/frontend/src/pages/quiz/QuizWaitingRoom.jsx
@@ -19,7 +19,6 @@ const QuizWaitingRoom = () => {
   const navigate = useNavigate();
   const [showExitModal, setShowExitModal] = useState(false);
   const [showRoomClosedAlert, setShowRoomClosedAlert] = useState(false);
-  // const [myUserId, setMyUserId] = useState(null);
 
   // Zustand에서 사용자 정보 가져오기
   const { user, isAuthenticated, hasCheckedAuth } = useAuthStore();
@@ -379,11 +378,6 @@ const QuizWaitingRoom = () => {
 
     if (data.success) {
       const roomData = data.data;
-
-      // TODO: 실제 로그인한 사용자 ID 가져오기
-      // 임시로 마지막 참가자를 "나"로 설정 (방금 입장한 사람)
-      // const myId = roomData.participants[roomData.participants.length - 1].userId;
-      // setMyUserId(myId); // state에 저장
 
       // 참가자 목록 업데이트
       const formattedParticipants = roomData.participants.map(p => ({


### PR DESCRIPTION
# Pull Request
**[Feat]: 퀴즈 대기방 연결 해제 및 예외 상황 처리 (#84)**

## PR 유형 (Type of PR)
- [x] 기능 (Feature)
- [ ] 버그 수정 (Bugfix)
- [ ] 기능 개선 (Enhancement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)

퀴즈 대기방에서 발생하는 모든 연결 해제 및 예외 상황을 안정적으로 처리합니다. 방장 퇴장, 참가자 퇴장, 비정상 종료(탭 닫기/새로고침) 등의 상황에서 리소스를 자동으로 정리하고 사용자에게 명확한 피드백을 제공합니다. 서버의 `onDisconnect` 이벤트를 활용한 자동 처리와 다중 경로의 방 종료 알림으로 안정성을 확보했습니다.

---

## 관련 이슈 (Related Issue)

- Closes #84

---

## 변경 사항 (Changes)

### 1. 나가기 버튼 및 확인 모달 구현
- 사용자가 명시적으로 방을 나갈 수 있는 "나가기" 버튼 추가
- `ConfirmModal`을 통한 나가기 확인 절차 구현
- 확인 시 리소스 정리 후 메인 페이지로 안전하게 이동

### 2. 방 종료 알림 시스템 구축
- `AlertModal`을 활용한 방 종료 알림 UI 구현
- 방장 퇴장 시 참가자들에게 "방장이 나가서 방이 종료되었습니다" 알림 표시
- 확인 버튼 클릭 시 리소스 정리 후 메인 페이지로 이동

### 3. 다중 경로 방 종료 이벤트 처리
백엔드에서 제공하는 3가지 경로를 통한 방 종료 감지:
- **경로 1**: `/user/queue/room-closed` 토픽의 `room:closed` 이벤트
- **경로 2**: `/topic/room/{id}/participant` 토픽의 `ROOM_CLOSED` 이벤트
- **경로 3**: `/topic/room/{id}/participant` 토픽의 `PARTICIPANT_LEFT` 이벤트 + `roomClosed: true` 플래그

### 4. 공통 리소스 정리 함수 구현
`cleanupAndExit` 함수로 중복 코드 제거 및 안전한 리소스 정리:
- Janus WebRTC 플러그인 정리 (pluginHandle, remoteFeed, userIdToFeedId 매핑)
- 웹캠 스트림 트랙 정지 (MediaStream.getTracks().stop())
- WebSocket 연결 해제 (websocketService.disconnect())
- 메인 페이지로 안전한 네비게이션

### 5. 비정상 종료 감지 및 처리
- `beforeunload` 이벤트 리스너 추가로 탭 닫기/새로고침 감지
- 클라이언트 리소스 즉시 정리 (Janus, 웹캠)
- 서버의 `onDisconnect` 이벤트 자동 감지로 DB 정리 및 브로드캐스팅

### 6. WebSocket 이벤트 핸들러 개선
- `QuizWaitingRoom` 컴포넌트에 `room:closed` 이벤트 구독/해제 추가
- 깨진 WebSocket 연결 예외 처리 강화 (try-catch)
- 이벤트 핸들러별 명확한 로그 추가로 디버깅 용이성 향상

### 7. 중복 방 입장 방지 (추가 테스트 케이스)
- 이미 방에 참가 중인 사용자가 다른 탭에서 URL로 접근 시 `alert` 경고
- 중복 세션 감지하여 방 참여 차단
- 참가자 퇴장 후 해당 사용자의 퀴즈 대기방 재입장 가능 확인

---

## 스크린샷 (Screenshots)

### 1. 나가기 버튼 및 확인 모달
> 사용자가 "나가기" 버튼을 클릭하면 나타나는 확인 모달 화면
<img width="959" height="943" alt="img" src="https://github.com/user-attachments/assets/44a30884-5d25-4268-99ed-b3ca9e811549" />



### 2. 방장이 나간 경우 - 참가자 화면
> 방장이 방을 나가면 참가자에게 표시되는 `AlertModal`
<img width="961" height="942" alt="img" src="https://github.com/user-attachments/assets/fe8f229c-8d73-4a19-ae6f-ce01022d43f5" />



### 3. 참가자가 나간 경우 - 방장 화면
> 참가자가 정상적으로 방을 나갔을 때 방장 화면에서 참가자 목록 업데이트
<img width="955" height="942" alt="img_2" src="https://github.com/user-attachments/assets/f3f6e0d8-ffaf-433f-8852-5d692892310c" />

### 4. 참가자 퇴장 후 재입장 가능 확인
> 참가자가 방을 나간 후 동일한 퀴즈 대기방에 다시 입장 가능한지 확인
<img width="1917" height="987" alt="img_1" src="https://github.com/user-attachments/assets/3cd8d265-876b-4341-99dc-0cc67e6a0914" />

### 5. 중복 방 입장 시도 차단
> 이미 방에 참가 중인 사용자가 다른 탭에서 동일한 방 URL로 접근 시도
<img width="1919" height="1028" alt="img_3" src="https://github.com/user-attachments/assets/f136b1ec-9582-49f7-b31c-e6cc91e76c04" />
<img width="956" height="1031" alt="img_4" src="https://github.com/user-attachments/assets/f8f2ff78-0763-4abf-81ee-476035bbeabf" />

---

## 테스트 방법 (Test Steps)

### 테스트 환경 준비
1. 로컬에서 프론트엔드와 백엔드 서버 실행
2. 두 개의 브라우저 또는 시크릿 모드로 두 명의 사용자 준비 (방장, 참가자)

### 시나리오 1: 나가기 버튼 동작 테스트
1. 방장으로 퀴즈 대기방 생성
2. "나가기" 버튼 클릭
3. 확인 모달에서 "나가기" 클릭
4. **예상 결과**: 리소스 정리 후 메인 페이지로 이동

### 시나리오 2: 방장 퇴장 시 참가자 알림
1. 방장으로 퀴즈 대기방 생성
2. 참가자가 방에 입장
3. 방장이 "나가기" 버튼 클릭 후 확인
4. **예상 결과**: 참가자 화면에 "방장이 나가서 방이 종료되었습니다" 알림 모달 표시
5. 참가자가 "확인" 버튼 클릭
6. **예상 결과**: 참가자도 메인 페이지로 이동

### 시나리오 3: 참가자 퇴장 후 재입장
1. 참가자로 퀴즈 대기방 입장
2. "나가기" 버튼으로 방 퇴장
3. 동일한 방 URL로 재입장 시도
4. **예상 결과**: 정상적으로 재입장 가능

### 시나리오 4: 비정상 종료 (탭 닫기)
1. 방장으로 퀴즈 대기방 생성
2. 참가자 입장
3. 방장이 탭 닫기 또는 브라우저 종료
4. **예상 결과**: 참가자 화면에 방 종료 알림 모달 표시

### 시나리오 5: 새로고침 시 리소스 정리
1. 퀴즈 대기방 입장 후 페이지 새로고침 (F5)
2. **예상 결과**: 
   - 클라이언트: Janus, 웹캠 리소스 즉시 정리
   - 서버: `onDisconnect` 이벤트로 DB 정리 및 다른 참가자에게 알림

### 시나리오 6: 중복 세션 차단
1. 퀴즈 대기방에 입장
2. 동일한 사용자가 다른 탭에서 같은 방 URL로 입장 시도
3. **예상 결과**: "이미 방에 참가 중입니다" 알림 표시 및 입장 차단

### 테스트 확인 사항
- 모든 시나리오에서 WebSocket 연결이 정상적으로 해제되는지 확인 (개발자 도구 Network 탭)
- Janus WebRTC 플러그인이 정리되었는지 확인 (콘솔 로그)
- 웹캠 스트림이 정지되었는지 확인 (카메라 LED 꺼짐)
- 브라우저 콘솔에 에러가 없는지 확인
- 서버 로그에서 `onDisconnect` 이벤트 처리 확인

---

## 셀프 체크리스트 (Self-Checklist)

- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [ ] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)

### 중점 검토 요청 사항

1. **다중 경로 이벤트 처리 로직**
   - 3가지 경로(`room:closed`, `ROOM_CLOSED`, `PARTICIPANT_LEFT`)로 방 종료를 감지하는 로직이 중복되거나 충돌하지 않는지 확인 부탁드립니다.
   - 특히 `handleParticipantEvent`의 `PARTICIPANT_LEFT` 케이스에서 `roomClosed` 플래그 처리 부분을 집중적으로 검토해주세요.

2. **리소스 정리 순서**
   - `cleanupAndExit` 함수에서 Janus → 웹캠 → WebSocket 순서로 정리하는 것이 적절한지 확인 부탁드립니다.
   - 특히 WebSocket 연결 해제 시 서버의 `onDisconnect`가 즉시 트리거되므로, 클라이언트 리소스 정리가 선행되어야 합니다.

3. **예외 처리 및 에러 핸들링**
   - 각 이벤트 핸들러의 try-catch 블록이 충분한지 확인 부탁드립니다.
   - WebSocket 연결이 이미 끊긴 상태에서 `unsubscribe` 시도 시 발생 가능한 에러 처리를 검토해주세요.

4. **비정상 종료 시나리오**
   - `beforeunload` 이벤트에서 브라우저 경고 메시지(`event.returnValue`)의 사용 여부
   - 현재는 주석 처리되어 있는데, UX 관점에서 활성화 여부 의견 부탁드립니다.

5. **중복 코드 리팩토링**
   - 2개의 커밋으로 분리되어 있습니다:
     - 커밋 1: 주요 기능 구현
     - 커밋 2: 불필요한 주석 및 미사용 상태(`myUserId`) 제거
   - 리팩토링 커밋이 기능에 영향을 주지 않았는지 확인 부탁드립니다.

### 참고 사항
- 서버 측 `WebSocketEventsListener.onDisconnect`는 이미 구현되어 있으며, 이 PR은 프론트엔드 처리에 집중합니다.
- 게임 페이지에도 동일한 패턴을 적용할 예정이므로, 재사용 가능한 구조로 설계되었습니다.
- 모든 테스트 시나리오는 로컬 환경에서 정상 동작 확인 완료했습니다.
