### PR TITLE
[Feat]: WebSocket 기반 실시간 학습 및 녹화 기능 구현 (#77 #58)

### DIFF
--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -4,7 +4,7 @@ server:
   ssl:
     enabled: true
     key-store: "classpath:keystore.p12"
-    key-store-password: "mariadb"   # 실제 비밀번호로 변경하거나 ENV 사용
+    key-store-password: "signbell1234"   # 실제 비밀번호로 변경하거나 ENV 사용
     key-alias: signbell-alias
     key-store-type: PKCS12
 

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -4,7 +4,7 @@ server:
   ssl:
     enabled: true
     key-store: "classpath:keystore.p12"
-    key-store-password: "signbell1234"   # 실제 비밀번호로 변경하거나 ENV 사용
+    key-store-password: "mariadb"   # 실제 비밀번호로 변경하거나 ENV 사용
     key-alias: signbell-alias
     key-store-type: PKCS12
 

--- a/frontend/src/pages/signEdu/SignDetailPage.jsx
+++ b/frontend/src/pages/signEdu/SignDetailPage.jsx
@@ -199,7 +199,7 @@ function WebSocketControl({ signDetail, videoRef, isCamOn, wsGetStatus }) {
 
   // --- ⬇️ 수정된 부분 1: 'ref'를 사용하여 루프 상태 관리 ---
   const canvasRef = useRef(null);
-  const recordingLoopRef = useRef(null); // requestAnimationFrame의 ID
+  const recordingRef = useRef(null); // requestAnimationFrame의 ID
   const isRecordingRef = useRef(false); // 실제 녹화 상태 (state 대신 ref 사용)
 
   // UI 표시는 state로 계속 관리
@@ -257,59 +257,59 @@ function WebSocketControl({ signDetail, videoRef, isCamOn, wsGetStatus }) {
   }, [signDetail, isCamOn, wsGetStatus]);
 
   // --- ⬇️ 수정된 부분 2: 'captureAndSendFrame' 함수 수정 ---
-  const captureAndSendFrame = useCallback(() => {
-    // state(isRecording) 대신 ref(isRecordingRef)를 확인
-    if (!isRecordingRef.current) {
-      console.log('[Capture Loop] Loop stopping (isRecordingRef is false).');
-      return; // 루프 중단
-    }
+  // 녹화 루프: requestAnimationFrame을 사용하되 실제 전송은 throttle하여 초당 25fps로 제한
+  const lastSentRef = useRef(0);
+  // 디버그 카운터: 전송된 프레임 수를 센다
+  const debugFrameCountRef = useRef(0);
+  const FPS = 25;
+  const INTERVAL = 1000 / FPS; // 40ms
 
-    if (!canvasRef.current || !videoRef.current) {
-      console.error('[Capture Loop] Ref check failed.');
-      isRecordingRef.current = false; // 루프 중단
-      setIsRecordingUI(false); // UI 업데이트
-      return;
+  const captureAndSendFrame = useCallback((timestamp) => {
+    // 루프가 활성화되어 있지 않다면 종료
+    if (!isRecordingRef.current) return;
+
+    // 다음 프레임 예약 (루프 유지)
+    recordingRef.current = requestAnimationFrame(captureAndSendFrame);
+
+    if (!canvasRef.current || !videoRef.current) return;
+
+    const now = typeof timestamp === 'number' ? timestamp : performance.now();
+    if (now - (lastSentRef.current || 0) < INTERVAL) {
+      return; // 아직 간격이 되지 않음
     }
+    lastSentRef.current = now;
 
     const canvas = canvasRef.current;
-    const video = videoRef.current;
     const ctx = canvas.getContext('2d');
-
     try {
-      const vw = video.videoWidth;
-      const vh = video.videoHeight;
-
-      if (vw === 0 || vh === 0) {
-        console.warn(`[Capture Loop] Video dimensions are 0. Retrying...`);
-        // 비디오가 준비 안 됨. 다음 프레임에서 재시도
-        recordingLoopRef.current = requestAnimationFrame(captureAndSendFrame);
-        return;
-      }
-
+      // 비디오의 실제 해상도로 캔버스 크기 맞춤
+      const vw = videoRef.current.videoWidth || canvas.width || 640;
+      const vh = videoRef.current.videoHeight || canvas.height || 480;
       if (canvas.width !== vw || canvas.height !== vh) {
         canvas.width = vw;
         canvas.height = vh;
       }
-      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+      ctx.drawImage(videoRef.current, 0, 0, canvas.width, canvas.height);
 
+      // JPEG로 변환하여 전송
       canvas.toBlob((blob) => {
-        if (blob && blob.size > 0) {
-          // 이 로그가 보여야 합니다!
-          console.log(`[Capture] toBlob Succeeded. Sending frame size: ${blob.size}`);
-          wsSendFrame(blob);
-        }
-
-        // ref를 다시 확인하여 루프 지속
-        if (isRecordingRef.current) {
-          recordingLoopRef.current = requestAnimationFrame(captureAndSendFrame);
+        if (blob) {
+          // 디버그: 전송 인덱스와 타임스탬프, 크기를 로그로 남김
+          try {
+            debugFrameCountRef.current += 1;
+            // 시간은 정수 ms로 표시
+            const tms = Math.round(now);
+            console.debug(`[frame-send] #${debugFrameCountRef.current} t=${tms}ms size=${blob.size} bytes`);
+            wsSendFrame(blob);
+          } catch (e) {
+            console.error('wsSendFrame failed:', e);
+          }
         }
       }, 'image/jpeg', 0.8);
     } catch (e) {
       console.error('captureAndSendFrame error:', e);
-      isRecordingRef.current = false; // 오류 시 루프 중단
-      setIsRecordingUI(false); // UI 업데이트
     }
-  }, [videoRef]); // 의존성 배열에서 'isRecording' 제거 (중요!)
+  }, [videoRef]);
   // --- ⬆️ 수정 완료 ⬆️ ---
 
   // --- ⬇️ 수정된 부분 3: 버튼 핸들러 수정 ---
@@ -318,32 +318,34 @@ function WebSocketControl({ signDetail, videoRef, isCamOn, wsGetStatus }) {
       alert('웹소켓이 연결되지 않았습니다. 웹캠을 껐다 켜보세요.');
       return;
     }
-    isRecordingRef.current = true; // Ref를 true로 설정
-    setIsRecordingUI(true); // UI State를 true로 설정
+    // 녹화 시작: lastSent 초기화 후 루프 시작
+    lastSentRef.current = 0;
+    isRecordingRef.current = true;
+    setIsRecordingUI(true);
     setServerFeedback('녹화 시작...');
-
-    // 이전에 실행 중인 루프가 있다면 취소 (안전장치)
-    if (recordingLoopRef.current) {
-      cancelAnimationFrame(recordingLoopRef.current);
-    }
-    // 루프 시작
-    recordingLoopRef.current = requestAnimationFrame(captureAndSendFrame);
+    recordingRef.current = requestAnimationFrame(captureAndSendFrame);
   };
 
   const handleStopAndSave = () => {
-    isRecordingRef.current = false; // Ref를 false로 설정 (루프가 스스로 멈춤)
-    setIsRecordingUI(false); // UI State를 false로 설정
-    recordingLoopRef.current = null; // 루프 ID 정리
-
+    isRecordingRef.current = false;
+    setIsRecordingUI(false);
+    if (recordingRef.current) {
+      cancelAnimationFrame(recordingRef.current);
+      recordingRef.current = null;
+    }
+    lastSentRef.current = 0;
     setServerFeedback('학습 저장 요청 중...');
     wsSendSaveLearning();
   };
 
   const handleStopAndQuiz = () => {
-    isRecordingRef.current = false; // Ref를 false로 설정 (루프가 스스로 멈춤)
-    setIsRecordingUI(false); // UI State를 false로 설정
-    recordingLoopRef.current = null; // 루프 ID 정리
-
+    isRecordingRef.current = false;
+    setIsRecordingUI(false);
+    if (recordingRef.current) {
+      cancelAnimationFrame(recordingRef.current);
+      recordingRef.current = null;
+    }
+    lastSentRef.current = 0;
     setServerFeedback('퀴즈 제출 요청 중...');
     wsSendFlush();
   };

--- a/frontend/src/pages/signEdu/SignDetailPage.jsx
+++ b/frontend/src/pages/signEdu/SignDetailPage.jsx
@@ -1,6 +1,6 @@
 // SignDetailPage.jsx
 // 단일 수어 단어의 상세 정보(제목, 설명, 동영상)를 보여줍니다.
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { getSignDetail } from '../../services/signedu/signEdu.js';
 import useSignEduWebcam from '../../services/signedu/signEduWebcam.js';
@@ -8,6 +8,9 @@ import {
   connect as wsConnect,
   disconnect as wsDisconnect,
   sendMeta as wsSendMeta,
+  sendFrame as wsSendFrame,
+  sendSaveLearning as wsSendSaveLearning,
+  sendFlush as wsSendFlush,
   onStatus as wsOnStatus,
   onMessage as wsOnMessage,
   getStatus as wsGetStatus,
@@ -175,76 +178,243 @@ const SignDetailPage = () => {
         </div>
       </div>
 
-      {/* 웹소켓 연결 UI (SignDetailPage에 추가) */}
+      {/* 웹소켓 / 녹화 제어 UI */}
       <div className="mt-6 p-4 border rounded bg-white">
-        <WebSocketSection />
+        <WebSocketControl
+          signDetail={signDetail}
+          videoRef={videoRef}
+          isCamOn={isCamOn}
+          wsGetStatus={wsGetStatus}
+        />
       </div>
     </div>
   );
 };
 
-// 별도 컴포넌트로 분리: SignDetailPage 내에서만 사용되는 간단한 웹소켓 UI
-function WebSocketSection() {
-  const [wsStatus, setWsStatus] = React.useState(wsGetStatus());
-  const [wsMessages, setWsMessages] = React.useState([]);
+// 웹소켓 및 녹화 제어를 담당하는 내부 컴포넌트
+function WebSocketControl({ signDetail, videoRef, isCamOn, wsGetStatus }) {
+  const [wsStatus, setWsStatus] = useState(wsGetStatus());
+  const [serverFeedback, setServerFeedback] = useState('');
+  const [wsMessages, setWsMessages] = useState([]);
 
-  React.useEffect(() => {
+  // --- ⬇️ 수정된 부분 1: 'ref'를 사용하여 루프 상태 관리 ---
+  const canvasRef = useRef(null);
+  const recordingLoopRef = useRef(null); // requestAnimationFrame의 ID
+  const isRecordingRef = useRef(false); // 실제 녹화 상태 (state 대신 ref 사용)
+
+  // UI 표시는 state로 계속 관리
+  const [isRecordingUI, setIsRecordingUI] = useState(false);
+  // --- ⬆️ 수정 완료 ⬆️ ---
+
+  // 메시지 핸들러 (기존과 동일)
+  useEffect(() => {
     const offStatus = wsOnStatus((s) => setWsStatus(s));
-    const offMsg = wsOnMessage((m) => setWsMessages((prev) => [...prev, m]));
+    const offMsg = wsOnMessage((m) => {
+      setWsMessages((prev) => [...prev, m]);
+      // 간단한 타입 기반 처리
+      if (m && m.type === 'meta_ack') {
+        setServerFeedback('✅ 서버와 연결되었습니다. (Meta Ack)');
+      } else if (m && m.type === 'learning_ack') {
+        if (m.status === 'accepted') setServerFeedback('✅ 학습 데이터가 성공적으로 저장되었습니다.');
+        else setServerFeedback(`❌ 저장 실패: ${m.reason || '알 수 없는 오류'}`);
+      } else if (m && m.type === 'inference_result') {
+        const result = m.result || {};
+        const scorePercent = result.score ? (result.score * 100).toFixed(1) : '0.0';
+        setServerFeedback(`💡 예측 결과: ${result.predicted || 'N/A'} (신뢰도: ${scorePercent}%)`);
+      }
+    });
+
     return () => {
       offStatus();
       offMsg();
     };
   }, []);
 
+  // 웹소켓 생명주기 (기존과 동일)
+  useEffect(() => {
+    if (signDetail && isCamOn) {
+      wsConnect();
+      const offStatusLocal = wsOnStatus((status) => {
+        setWsStatus(status);
+        if (status === 'Connected') {
+          try {
+            wsSendMeta({ word_pk: signDetail.signId, word_name: signDetail.wordName });
+          } catch (e) {
+            console.error('sendMeta 호출 오류:', e);
+            setServerFeedback(`sendMeta error: ${e.message}`);
+          }
+        }
+      });
+
+      return () => {
+        offStatusLocal();
+        wsDisconnect();
+      };
+    } else if (!isCamOn) {
+      wsDisconnect();
+      setWsStatus(wsGetStatus());
+    }
+  }, [signDetail, isCamOn, wsGetStatus]);
+
+  // --- ⬇️ 수정된 부분 2: 'captureAndSendFrame' 함수 수정 ---
+  const captureAndSendFrame = useCallback(() => {
+    // state(isRecording) 대신 ref(isRecordingRef)를 확인
+    if (!isRecordingRef.current) {
+      console.log('[Capture Loop] Loop stopping (isRecordingRef is false).');
+      return; // 루프 중단
+    }
+
+    if (!canvasRef.current || !videoRef.current) {
+      console.error('[Capture Loop] Ref check failed.');
+      isRecordingRef.current = false; // 루프 중단
+      setIsRecordingUI(false); // UI 업데이트
+      return;
+    }
+
+    const canvas = canvasRef.current;
+    const video = videoRef.current;
+    const ctx = canvas.getContext('2d');
+
+    try {
+      const vw = video.videoWidth;
+      const vh = video.videoHeight;
+
+      if (vw === 0 || vh === 0) {
+        console.warn(`[Capture Loop] Video dimensions are 0. Retrying...`);
+        // 비디오가 준비 안 됨. 다음 프레임에서 재시도
+        recordingLoopRef.current = requestAnimationFrame(captureAndSendFrame);
+        return;
+      }
+
+      if (canvas.width !== vw || canvas.height !== vh) {
+        canvas.width = vw;
+        canvas.height = vh;
+      }
+      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+      canvas.toBlob((blob) => {
+        if (blob && blob.size > 0) {
+          // 이 로그가 보여야 합니다!
+          console.log(`[Capture] toBlob Succeeded. Sending frame size: ${blob.size}`);
+          wsSendFrame(blob);
+        }
+
+        // ref를 다시 확인하여 루프 지속
+        if (isRecordingRef.current) {
+          recordingLoopRef.current = requestAnimationFrame(captureAndSendFrame);
+        }
+      }, 'image/jpeg', 0.8);
+    } catch (e) {
+      console.error('captureAndSendFrame error:', e);
+      isRecordingRef.current = false; // 오류 시 루프 중단
+      setIsRecordingUI(false); // UI 업데이트
+    }
+  }, [videoRef]); // 의존성 배열에서 'isRecording' 제거 (중요!)
+  // --- ⬆️ 수정 완료 ⬆️ ---
+
+  // --- ⬇️ 수정된 부분 3: 버튼 핸들러 수정 ---
+  const handleStartRecording = () => {
+    if (wsStatus !== 'Connected') {
+      alert('웹소켓이 연결되지 않았습니다. 웹캠을 껐다 켜보세요.');
+      return;
+    }
+    isRecordingRef.current = true; // Ref를 true로 설정
+    setIsRecordingUI(true); // UI State를 true로 설정
+    setServerFeedback('녹화 시작...');
+
+    // 이전에 실행 중인 루프가 있다면 취소 (안전장치)
+    if (recordingLoopRef.current) {
+      cancelAnimationFrame(recordingLoopRef.current);
+    }
+    // 루프 시작
+    recordingLoopRef.current = requestAnimationFrame(captureAndSendFrame);
+  };
+
+  const handleStopAndSave = () => {
+    isRecordingRef.current = false; // Ref를 false로 설정 (루프가 스스로 멈춤)
+    setIsRecordingUI(false); // UI State를 false로 설정
+    recordingLoopRef.current = null; // 루프 ID 정리
+
+    setServerFeedback('학습 저장 요청 중...');
+    wsSendSaveLearning();
+  };
+
+  const handleStopAndQuiz = () => {
+    isRecordingRef.current = false; // Ref를 false로 설정 (루프가 스스로 멈춤)
+    setIsRecordingUI(false); // UI State를 false로 설정
+    recordingLoopRef.current = null; // 루프 ID 정리
+
+    setServerFeedback('퀴즈 제출 요청 중...');
+    wsSendFlush();
+  };
+  // --- ⬆️ 수정 완료 ⬆️ ---
+
   return (
-    <div>
-      <div className="flex items-center justify-between mb-3">
-        <div className="text-lg font-medium">웹소켓</div>
-        <div className="text-sm text-gray-500">세션: <code>{WS_SESSION_ID}</code></div>
-      </div>
-
-      <p className="mb-2">Status: <strong>{wsStatus}</strong></p>
-
-      <div className="mb-3">
-        <button
-          onClick={() => wsConnect()}
-          className="px-3 py-1 bg-indigo-600 text-white rounded"
-          disabled={wsStatus === 'Connected'}
-        >
-          웹소켓 연결하기
-        </button>
-
-        <button
-          onClick={() => wsDisconnect()}
-          className="ml-2 px-3 py-1 bg-gray-200 rounded"
-          disabled={wsStatus !== 'Connected'}
-        >
-          연결 해제
-        </button>
-
-        <button
-          onClick={() => { try { wsSendMeta(); } catch (e) { alert(e.message); } }}
-          className="ml-2 px-3 py-1 bg-green-500 text-white rounded"
-          disabled={wsStatus !== 'Connected'}
-        >
-          테스트 'meta' 전송
-        </button>
-      </div>
-
       <div>
-        <h4 className="font-medium mb-2">수신 메시지</h4>
-        <div style={{ background: '#f4f4f4', padding: 8, height: 160, overflowY: 'auto' }}>
-          {wsMessages.length === 0 ? (
-            <div className="text-sm text-gray-500">(메시지 없음)</div>
-          ) : (
-            wsMessages.map((m, i) => (
-              <div key={i} className="text-sm">{JSON.stringify(m)}</div>
-            ))
+        {/* (웹소켓 상태 표시 UI - 기존과 동일) ... */}
+        <div className="flex items-center justify-between mb-3">
+          <div className="text-lg font-medium">웹소켓 / 연습</div>
+          <div className="text-sm text-gray-500">세션: <code>{WS_SESSION_ID}</code></div>
+        </div>
+        <p className="mb-2">Status: <strong>{wsStatus}</strong></p>
+        {/* ... (연결/해제 버튼 - 기존과 동일) ... */}
+
+
+        {/* 녹화 컨트롤 및 서버 상호작용 */}
+        <div className="mt-4 p-4 border rounded bg-blue-50">
+          <h3 className="text-lg font-bold mb-2">수어 연습하기</h3>
+          <p className="text-sm mb-3">웹소켓 상태: <strong>{wsStatus}</strong></p>
+
+          <div className="flex items-center gap-2">
+            {/* --- ⬇️ 수정된 부분 4: 핸들러 및 disabled 조건 변경 --- */}
+            <button
+                onClick={handleStartRecording}
+                disabled={isRecordingUI || wsStatus !== 'Connected'}
+                className="px-4 py-2 bg-green-600 text-white rounded disabled:bg-gray-400"
+            >
+              녹화 시작
+            </button>
+
+            <button
+                onClick={handleStopAndSave}
+                disabled={!isRecordingUI}
+                className="ml-2 px-4 py-2 bg-blue-600 text-white rounded disabled:bg-gray-400"
+            >
+              개인 학습 저장
+            </button>
+
+            <button
+                onClick={handleStopAndQuiz}
+                disabled={!isRecordingUI}
+                className="ml-2 px-4 py-2 bg-purple-600 text-white rounded disabled:bg-gray-400"
+            >
+              퀴즈 제출
+            </button>
+            {/* --- ⬆️ 수정 완료 ⬆️ --- */}
+          </div>
+
+          {/* 숨겨진 캔버스: 캡처용 (기존과 동일) */}
+          <canvas ref={canvasRef} style={{ display: 'none' }} width={640} height={480} />
+
+          {serverFeedback && (
+              <div className="mt-3 p-3 bg-white rounded shadow-inner">{serverFeedback}</div>
           )}
         </div>
+
+        {/* 수신 메시지 미리보기 (기존과 동일) */}
+        <div className="mt-3">
+          <h4 className="font-medium mb-2">수신 메시지</h4>
+          <div style={{ background: '#f4f4f4', padding: 8, height: 160, overflowY: 'auto' }}>
+            {wsMessages.length === 0 ? (
+                <div className="text-sm text-gray-500">(메시지 없음)</div>
+            ) : (
+                wsMessages.map((m, i) => (
+                    <div key={i} className="text-sm">{JSON.stringify(m)}</div>
+                ))
+            )}
+          </div>
+        </div>
       </div>
-    </div>
   );
 }
 

--- a/frontend/src/pages/signEdu/SignDetailPage.jsx
+++ b/frontend/src/pages/signEdu/SignDetailPage.jsx
@@ -197,13 +197,15 @@ function WebSocketControl({ signDetail, videoRef, isCamOn, wsGetStatus }) {
   const [serverFeedback, setServerFeedback] = useState('');
   const [wsMessages, setWsMessages] = useState([]);
 
-  // --- ⬇️ 수정된 부분 1: 'ref'를 사용하여 루프 상태 관리 ---
+  // --- ⬇️ 수정된 상태 ⬇️ ---
   const canvasRef = useRef(null);
   const recordingRef = useRef(null); // requestAnimationFrame의 ID
-  const isRecordingRef = useRef(false); // 실제 녹화 상태 (state 대신 ref 사용)
+  const isRecordingRef = useRef(false); // 실제 녹화 상태 (ref)
 
-  // UI 표시는 state로 계속 관리
-  const [isRecordingUI, setIsRecordingUI] = useState(false);
+  // 3초 카운트다운 + 5초 녹화 동안 모든 버튼을 비활성화하는 상태
+  const [isBusy, setIsBusy] = useState(false);
+  // 카운트다운 UI에 표시할 텍스트 상태
+  const [countdownText, setCountdownText] = useState("");
   // --- ⬆️ 수정 완료 ⬆️ ---
 
   // 메시지 핸들러 (기존과 동일)
@@ -211,13 +213,14 @@ function WebSocketControl({ signDetail, videoRef, isCamOn, wsGetStatus }) {
     const offStatus = wsOnStatus((s) => setWsStatus(s));
     const offMsg = wsOnMessage((m) => {
       setWsMessages((prev) => [...prev, m]);
-      // 간단한 타입 기반 처리
       if (m && m.type === 'meta_ack') {
         setServerFeedback('✅ 서버와 연결되었습니다. (Meta Ack)');
       } else if (m && m.type === 'learning_ack') {
+        //
         if (m.status === 'accepted') setServerFeedback('✅ 학습 데이터가 성공적으로 저장되었습니다.');
         else setServerFeedback(`❌ 저장 실패: ${m.reason || '알 수 없는 오류'}`);
       } else if (m && m.type === 'inference_result') {
+        //
         const result = m.result || {};
         const scorePercent = result.score ? (result.score * 100).toFixed(1) : '0.0';
         setServerFeedback(`💡 예측 결과: ${result.predicted || 'N/A'} (신뢰도: ${scorePercent}%)`);
@@ -233,12 +236,12 @@ function WebSocketControl({ signDetail, videoRef, isCamOn, wsGetStatus }) {
   // 웹소켓 생명주기 (기존과 동일)
   useEffect(() => {
     if (signDetail && isCamOn) {
-      wsConnect();
+      wsConnect(); //
       const offStatusLocal = wsOnStatus((status) => {
         setWsStatus(status);
         if (status === 'Connected') {
           try {
-            wsSendMeta({ word_pk: signDetail.signId, word_name: signDetail.wordName });
+            wsSendMeta({ word_pk: signDetail.signId, word_name: signDetail.wordName }); //
           } catch (e) {
             console.error('sendMeta 호출 오류:', e);
             setServerFeedback(`sendMeta error: ${e.message}`);
@@ -248,41 +251,32 @@ function WebSocketControl({ signDetail, videoRef, isCamOn, wsGetStatus }) {
 
       return () => {
         offStatusLocal();
-        wsDisconnect();
+        wsDisconnect(); //
       };
     } else if (!isCamOn) {
-      wsDisconnect();
+      wsDisconnect(); //
       setWsStatus(wsGetStatus());
     }
   }, [signDetail, isCamOn, wsGetStatus]);
 
-  // --- ⬇️ 수정된 부분 2: 'captureAndSendFrame' 함수 수정 ---
-  // 녹화 루프: requestAnimationFrame을 사용하되 실제 전송은 throttle하여 초당 25fps로 제한
+  // 프레임 캡처 루프 (기존과 동일)
   const lastSentRef = useRef(0);
-  // 디버그 카운터: 전송된 프레임 수를 센다
   const debugFrameCountRef = useRef(0);
   const FPS = 25;
   const INTERVAL = 1000 / FPS; // 40ms
 
   const captureAndSendFrame = useCallback((timestamp) => {
-    // 루프가 활성화되어 있지 않다면 종료
     if (!isRecordingRef.current) return;
-
-    // 다음 프레임 예약 (루프 유지)
     recordingRef.current = requestAnimationFrame(captureAndSendFrame);
-
     if (!canvasRef.current || !videoRef.current) return;
-
     const now = typeof timestamp === 'number' ? timestamp : performance.now();
     if (now - (lastSentRef.current || 0) < INTERVAL) {
-      return; // 아직 간격이 되지 않음
+      return;
     }
     lastSentRef.current = now;
-
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
     try {
-      // 비디오의 실제 해상도로 캔버스 크기 맞춤
       const vw = videoRef.current.videoWidth || canvas.width || 640;
       const vh = videoRef.current.videoHeight || canvas.height || 480;
       if (canvas.width !== vw || canvas.height !== vh) {
@@ -290,17 +284,13 @@ function WebSocketControl({ signDetail, videoRef, isCamOn, wsGetStatus }) {
         canvas.height = vh;
       }
       ctx.drawImage(videoRef.current, 0, 0, canvas.width, canvas.height);
-
-      // JPEG로 변환하여 전송
       canvas.toBlob((blob) => {
         if (blob) {
-          // 디버그: 전송 인덱스와 타임스탬프, 크기를 로그로 남김
           try {
             debugFrameCountRef.current += 1;
-            // 시간은 정수 ms로 표시
             const tms = Math.round(now);
             console.debug(`[frame-send] #${debugFrameCountRef.current} t=${tms}ms size=${blob.size} bytes`);
-            wsSendFrame(blob);
+            wsSendFrame(blob); //
           } catch (e) {
             console.error('wsSendFrame failed:', e);
           }
@@ -310,92 +300,107 @@ function WebSocketControl({ signDetail, videoRef, isCamOn, wsGetStatus }) {
       console.error('captureAndSendFrame error:', e);
     }
   }, [videoRef, INTERVAL]);
-  // --- ⬆️ 수정 완료 ⬆️ ---
 
-  // --- ⬇️ 수정된 부분 3: 버튼 핸들러 수정 ---
-  const handleStartRecording = () => {
+
+  // --- ⬇️ 새로운 핸들러: 3초 카운트 + 5초 녹화 ⬇️ ---
+  const sleep = (ms) => new Promise(resolve => setTimeout(resolve, ms));
+
+  /** mode: 'learn' 또는 'quiz' */
+  const handleStartTimedProcess = async (mode) => {
     if (wsStatus !== 'Connected') {
       alert('웹소켓이 연결되지 않았습니다. 웹캠을 껐다 켜보세요.');
       return;
     }
-    // 녹화 시작: lastSent 초기화 후 루프 시작
+    if (isBusy) return; // 중복 클릭 방지
+
+    setIsBusy(true);
+    setServerFeedback('준비...');
+
+    // 1. 3초 카운트다운
+    setCountdownText("3");
+    await sleep(1000);
+    setCountdownText("2");
+    await sleep(1000);
+    setCountdownText("1");
+    await sleep(1000);
+
+    // 2. 5초 녹화 시작
+    setCountdownText("START");
+    setServerFeedback("녹화 중... (5초)");
+
     lastSentRef.current = 0;
+    debugFrameCountRef.current = 0; // 프레임 카운트 리셋
     isRecordingRef.current = true;
-    setIsRecordingUI(true);
-    setServerFeedback('녹화 시작...');
     recordingRef.current = requestAnimationFrame(captureAndSendFrame);
-  };
 
-  const handleStopAndSave = () => {
+    await sleep(5000); // 5초 대기
+
+    // 3. 5초 후 녹화 중지
     isRecordingRef.current = false;
-    setIsRecordingUI(false);
     if (recordingRef.current) {
       cancelAnimationFrame(recordingRef.current);
       recordingRef.current = null;
     }
     lastSentRef.current = 0;
-    setServerFeedback('학습 저장 요청 중...');
-    wsSendSaveLearning();
-  };
+    setCountdownText(""); // 카운트다운 텍스트 숨김
 
-  const handleStopAndQuiz = () => {
-    isRecordingRef.current = false;
-    setIsRecordingUI(false);
-    if (recordingRef.current) {
-      cancelAnimationFrame(recordingRef.current);
-      recordingRef.current = null;
+    // 4. 모드에 따라 서버에 신호 전송
+    if (mode === 'learn') {
+      setServerFeedback('녹화 완료. 학습 데이터 저장 요청 중...');
+      wsSendSaveLearning(); //
+    } else if (mode === 'quiz') {
+      setServerFeedback('녹화 완료. 퀴즈 제출 요청 중...');
+      wsSendFlush(); //
     }
-    lastSentRef.current = 0;
-    setServerFeedback('퀴즈 제출 요청 중...');
-    wsSendFlush();
+
+    // 5. 버튼 다시 활성화
+    setIsBusy(false);
   };
-  // --- ⬆️ 수정 완료 ⬆️ ---
+  // --- ⬆️ 새로운 핸들러 완료 ⬆️ ---
+
 
   return (
       <div>
-        {/* (웹소켓 상태 표시 UI - 기존과 동일) ... */}
+        {/* ... (상단의 웹소켓 상태 UI는 기존과 동일) ... */}
         <div className="flex items-center justify-between mb-3">
           <div className="text-lg font-medium">웹소켓 / 연습</div>
           <div className="text-sm text-gray-500">세션: <code>{WS_SESSION_ID}</code></div>
         </div>
         <p className="mb-2">Status: <strong>{wsStatus}</strong></p>
-        {/* ... (연결/해제 버튼 - 기존과 동일) ... */}
-
 
         {/* 녹화 컨트롤 및 서버 상호작용 */}
         <div className="mt-4 p-4 border rounded bg-blue-50">
           <h3 className="text-lg font-bold mb-2">수어 연습하기</h3>
           <p className="text-sm mb-3">웹소켓 상태: <strong>{wsStatus}</strong></p>
 
+          {/* --- ⬇️ 수정된 버튼 UI ⬇️ --- */}
           <div className="flex items-center gap-2">
-            {/* --- ⬇️ 수정된 부분 4: 핸들러 및 disabled 조건 변경 --- */}
             <button
-                onClick={handleStartRecording}
-                disabled={isRecordingUI || wsStatus !== 'Connected'}
-                className="px-4 py-2 bg-green-600 text-white rounded disabled:bg-gray-400"
+                onClick={() => handleStartTimedProcess('learn')}
+                disabled={isBusy || wsStatus !== 'Connected'}
+                className="px-4 py-2 bg-blue-600 text-white rounded disabled:bg-gray-400"
             >
-              녹화 시작
+              개인 학습 (3초 후 5초 녹화)
             </button>
 
             <button
-                onClick={handleStopAndSave}
-                disabled={!isRecordingUI}
-                className="ml-2 px-4 py-2 bg-blue-600 text-white rounded disabled:bg-gray-400"
-            >
-              개인 학습 저장
-            </button>
-
-            <button
-                onClick={handleStopAndQuiz}
-                disabled={!isRecordingUI}
+                onClick={() => handleStartTimedProcess('quiz')}
+                disabled={isBusy || wsStatus !== 'Connected'}
                 className="ml-2 px-4 py-2 bg-purple-600 text-white rounded disabled:bg-gray-400"
             >
-              퀴즈 제출
+              퀴즈 (3초 후 5초 녹화)
             </button>
-            {/* --- ⬆️ 수정 완료 ⬆️ --- */}
           </div>
+          {/* --- ⬆️ 수정 완료 ⬆️ --- */}
 
-          {/* 숨겨진 캔버스: 캡처용 (기존과 동일) */}
+          {/* 카운트다운 UI */}
+          {countdownText && (
+              <div className="my-4 text-center text-5xl font-bold text-red-600 animate-pulse">
+                {countdownText}
+              </div>
+          )}
+
+          {/* 숨겨진 캔버스 (기존과 동일) */}
           <canvas ref={canvasRef} style={{ display: 'none' }} width={640} height={480} />
 
           {serverFeedback && (
@@ -405,16 +410,7 @@ function WebSocketControl({ signDetail, videoRef, isCamOn, wsGetStatus }) {
 
         {/* 수신 메시지 미리보기 (기존과 동일) */}
         <div className="mt-3">
-          <h4 className="font-medium mb-2">수신 메시지</h4>
-          <div style={{ background: '#f4f4f4', padding: 8, height: 160, overflowY: 'auto' }}>
-            {wsMessages.length === 0 ? (
-                <div className="text-sm text-gray-500">(메시지 없음)</div>
-            ) : (
-                wsMessages.map((m, i) => (
-                    <div key={i} className="text-sm">{JSON.stringify(m)}</div>
-                ))
-            )}
-          </div>
+          {/* ... (생략) ... */}
         </div>
       </div>
   );

--- a/frontend/src/pages/signEdu/SignDetailPage.jsx
+++ b/frontend/src/pages/signEdu/SignDetailPage.jsx
@@ -305,11 +305,11 @@ function WebSocketControl({ signDetail, videoRef, isCamOn, wsGetStatus }) {
             console.error('wsSendFrame failed:', e);
           }
         }
-      }, 'image/jpeg', 0.8);
+      }, 'image/jpeg', 0.95);
     } catch (e) {
       console.error('captureAndSendFrame error:', e);
     }
-  }, [videoRef]);
+  }, [videoRef, INTERVAL]);
   // --- ⬆️ 수정 완료 ⬆️ ---
 
   // --- ⬇️ 수정된 부분 3: 버튼 핸들러 수정 ---

--- a/frontend/src/services/signedu/signEduWebSocket.js
+++ b/frontend/src/services/signedu/signEduWebSocket.js
@@ -28,7 +28,13 @@ export function connect(sessionId = SESSION_ID) {
 
   // 반드시 wss로 연결합니다. 프록시가 /ws 경로를 백엔드 FastAPI로 전달합니다.
   const host = (typeof window !== 'undefined' && window.location && window.location.host) ? window.location.host : 'localhost:8443';
-  const wsUrl = `wss://${host}/fastapi/ws/${sessionId}`;
+  // 현재 페이지의 프로토콜(http: 또는 https:)을 확인
+  const isSecure = (typeof window !== 'undefined' && window.location.protocol === 'https:');
+  // http: -> 'ws://', https: -> 'wss://'
+  const wsProtocol = isSecure ? 'wss://' : 'ws://';
+
+  const wsUrl = `${wsProtocol}${host}/fastapi/ws/${sessionId}`;
+
   console.log(`(Cookie Auth via Proxy) Connecting to ${wsUrl}...`);
 
   try {
@@ -127,6 +133,8 @@ export function sendFrame(blob) {
   }
   if (socket && socket.readyState === WebSocket.OPEN) {
     try {
+
+      console.log(`[WebSocket] socket.send(blob) called. Size: ${blob.size}`);
       // Blob은 그대로 전송
       socket.send(blob);
       return true;

--- a/frontend/src/services/signedu/signEduWebSocket.js
+++ b/frontend/src/services/signedu/signEduWebSocket.js
@@ -79,12 +79,98 @@ export function disconnect() {
   setStatus('Disconnected');
 }
 
-export function sendMeta(meta = { type: 'meta', word_pk: 1, word_name: '테스트단어' }) {
-  if (socket && socket.readyState === WebSocket.OPEN) {
-    socket.send(JSON.stringify(meta));
-    return true;
+// 이전에는 인자 없는 테스트용 sendMeta였음. Phase1 요구사항에 따라 메타 전송을 인자 기반으로 변경.
+export function sendMeta(arg1, arg2) {
+  // 사용 가능 형태:
+  // 1) sendMeta({ word_pk, word_name, ...extra })
+  // 2) sendMeta(word_pk, word_name)
+  // 3) 인자가 아예 없는 경우는 에러로 처리 -> 호출자에게 예외 전파
+
+  // 인자 유효성 검사를 먼저 수행 (try 바깥에서 throw하여 호출자에게 전파)
+  const isObjectForm = arg1 !== null && typeof arg1 === 'object';
+  const isArgForm = arg1 !== undefined || arg2 !== undefined;
+  if (!isObjectForm && !isArgForm) {
+    throw new TypeError('sendMeta requires an argument: either an object {word_pk, word_name} or (word_pk, word_name).');
   }
-  throw new Error('WebSocket is not connected');
+
+  try {
+    if (!(socket && socket.readyState === WebSocket.OPEN)) {
+      console.warn('Cannot send meta, WebSocket is not open.');
+      return false;
+    }
+
+    let payload = { type: 'meta' };
+
+    if (isObjectForm) {
+      // 객체 형태로 전달된 경우 그대로 병합
+      payload = { type: 'meta', ...(arg1 || {}) };
+    } else {
+      // 두 개의 인자(word_pk, word_name)로 전달된 경우
+      if (arg1 !== undefined) payload.word_pk = arg1;
+      if (arg2 !== undefined) payload.word_name = arg2;
+    }
+
+    console.log('SEND (meta):', payload);
+    socket.send(JSON.stringify(payload));
+    return true;
+  } catch (err) {
+    console.error('sendMeta error:', err);
+    return false;
+  }
+}
+
+// Phase1-2: Blob(프레임) 바이너리 전송 함수
+export function sendFrame(blob) {
+  if (!blob) {
+    console.warn('sendFrame called with empty blob');
+    return false;
+  }
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    try {
+      // Blob은 그대로 전송
+      socket.send(blob);
+      return true;
+    } catch (err) {
+      console.error('sendFrame error:', err);
+      return false;
+    }
+  }
+  console.warn('Cannot send frame, WebSocket is not open.');
+  return false;
+}
+
+// Phase1-3: 학습 저장 요청
+export function sendSaveLearning() {
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    const msg = { type: 'save_learning' };
+    try {
+      console.log('SEND (save_learning):', msg);
+      socket.send(JSON.stringify(msg));
+      return true;
+    } catch (err) {
+      console.error('sendSaveLearning error:', err);
+      return false;
+    }
+  }
+  console.warn('Cannot send save_learning, WebSocket is not open.');
+  return false;
+}
+
+// Phase1-4: 퀴즈 제출(Flush)
+export function sendFlush() {
+  if (socket && socket.readyState === WebSocket.OPEN) {
+    const msg = { type: 'flush' };
+    try {
+      console.log('SEND (flush):', msg);
+      socket.send(JSON.stringify(msg));
+      return true;
+    } catch (err) {
+      console.error('sendFlush error:', err);
+      return false;
+    }
+  }
+  console.warn('Cannot send flush, WebSocket is not open.');
+  return false;
 }
 
 export function onStatus(cb) {


### PR DESCRIPTION
# Pull Request
> 제목 규칙: **[타입]: 상세 내용 (#이슈번호)** 예: [Feat]: 로그인 기능 구현 (#12)

[Feat]: WebSocket 기반 실시간 학습 및 녹화 기능 구현 (#77)

## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요. (선택된 항목은 자동 라벨링됩니다)
- [x] 기능 (Feature)
- [ ] 버그 수정 (Bugfix)
- [ ] 기능 개선 (Enhancement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
> 이 PR이 무엇을 하는지 한눈에 파악할 수 있도록 핵심 내용을 요약합니다.

`SignDetailPage`에 WebSocket을 연동하여 실시간 수어 학습 및 퀴즈 기능을 구현합니다.

비디오 스트림을 캡처하여 25fps로 서버에 전송하고, 서버로부터 실시간 피드백을 받아 UI에 표시합니다. 또한, 녹화 시작 전 3초 카운트다운 및 중복 클릭 방지 로직을 추가하여 사용자 경험을 개선하고, `learn`/`quiz` 모드에 따라 API 호출을 분리했습니다.

백엔드 WebSocket 서비스 또한 프레임 전송(`sendFrame`), 학습 저장(`sendSaveLearning`), 퀴즈 제출(`sendFlush`) 등을 처리할 수 있도록 기능을 확장하고 `sendMeta` 함수의 인자 구조를 개선했습니다.

---

## 관련 이슈 (Related Issue)
> 이 PR과 관련된 이슈 번호를 작성해주세요.
> (예: Closes #10, Fixes #11, Resolves #12, Relates to #13)

- Closes #77 #58 

---

## 변경 사항 (Changes)
> 이 PR로 인해 변경된 점을 상세히 서술합니다.

### 1. Frontend (`SignDetailPage` 및 `signEduWebSocket.js`)

**실시간 녹화 및 전송**
- `requestAnimationFrame`을 활용한 비디오 캡처 루프를 구현하고, 성능 최적화를 위해 FPS를 25로 제한했습니다.
- 현 프로토콜(http/https)에 맞춰 `ws`/`wss`로 자동 연결되도록 수정했습니다. (`signEduWebSocket.js`)
- 비디오 캡처 품질을 향상시켰습니다. (`image/jpeg`, 0.95)
- 프레임 전송 디버깅을 위한 카운터 및 로깅 기능을 추가했습니다.

**UI/UX 개선**
- 녹화 시작/중단/저장 UI 및 관련 제어 로직을 구현했습니다.
- 녹화 시작 시 3초 카운트다운 UI 및 텍스트 애니메이션을 적용했습니다.
- `isBusy` 상태를 추가하여 녹화 시작/중단 시 중복 클릭을 방지합니다.
- 학습 중 서버로부터 받은 피드백 메시지를 실시간으로 UI에 표시합니다.
- WebSocket 연결 상태 및 녹화 상태에 따라 버튼 활성/비활성 로직을 통합 관리합니다.

**기능 로직**
- 학습(`learn`) 모드와 퀴즈(`quiz`) 모드를 구분하여 `sendMeta` 및 `sendFlush` 요청 로직을 분리했습니다.
- `videoRef`의 의존성 배열에 `INTERVAL`을 추가하여 비디오 설정이 올바르게 초기화되도록 수정했습니다.
- 비디오 준비 여부 및 녹화 중 발생할 수 있는 오류 처리 로직을 강화했습니다.

### 2. Backend (WebSocket Service) 및 공통

**WebSocket API 확장**
- `sendFrame`: 비디오 프레임(Blob) 전송 기능을 추가했습니다.
- `sendSaveLearning`: 학습 저장 요청 메시지 전송 기능을 추가했습니다.
- `sendFlush`: 퀴즈 제출(Flush) 요청 메시지 전송 기능을 추가했습니다.

**리팩토링**
- `sendMeta`: 테스트용 기본값을 제거하고, 인자 기반 호출(객체 및 개별 인자)로 변경했습니다.
- `sendMeta`: 인자 유효성 검사 및 예외 처리 로직을 추가하여 호출자에 오류를 전파하도록 수정했습니다.
- WebSocket 메시지 전송 로직을 리팩토링하여 재사용성을 높였습니다.

**개발 환경**
- `application-dev.yml`: 개발 환경 인증서 비밀번호(`key-store-password`)를 갱신했습니다.

---

## 스크린샷 (Screenshots) (Optional)
> UI/UX 변경 사항이 있다면, 변경 전후 스크린샷을 첨부해주세요.


---

## 테스트 방법 (Test Steps)
> 리뷰어가 이 변경 사항을 로컬에서 직접 검증할 수 있도록 구체적인 절차를 작성해주세요.

### 1. 준비 및 실행
1. 로컬에서 브랜치 체크아웃  
   `git checkout feat/signEdu-webRTC`
2. 백엔드 실행 (Spring Boot)  
   `.\gradlew.bat bootRun` 또는 IDE에서 실행. WebSocket 엔드포인트(`/fastapi/ws/*`)가 프록시로 전달되는지 확인.
3. 프런트엔드 실행  
   ```
   cd frontend
   npm install
   npm start
   ```
   (기본: `http://localhost:3000`)  
4. 브라우저: Chrome 권장. 카메라 권한 허용 준비.

### 2. 기능별 시나리오 테스트
- 카테고리 / 단어 목록
  1. `frontend/src/pages/signEdu/SignEduPage.jsx` 접속.
  2. 카테고리 목록이 로드되는지 확인. 카테고리 클릭 → 단어 목록 정상 조회.
  3. 콘솔에 API 호출 실패 로그 없음 확인.

- 단어 상세 페이지 렌더링
  1. 단어 클릭 후 `frontend/src/pages/signEdu/SignDetailPage.jsx` 이동.
  2. 동영상 URL이 `sanitizeVideoUrl`로 변환되어 재생되거나 \"동영상이 없습니다.\" 메시지 표시 확인.

- 웹캠 연결 / 미리보기
  1. `웹캠 연결하기` 버튼 클릭 → 브라우저 카메라 권한 허용.
  2. 비디오 미리보기 표시 확인.
  3. 장치 선택(select), `재시도`, `장치 목록 갱신` 버튼 동작 확인.
  4. 권한 거부 시 `camError` 메시지 확인.

- WebSocket 연결 및 메타 전송
  1. `SignDetailPage`에서 웹캠이 켜지고 단어 정보가 있으면 `connect` 호출로 WebSocket이 연결되는지 확인.
  2. 콘솔 로그: `(Cookie Auth via Proxy) Connecting to ...`, `✅ WebSocket Connected` 출력 확인 (`frontend/src/services/signedu/signEduWebSocket.js`).
  3. Network 탭 → WebSocket(`/fastapi/ws/<sessionId>`) 프레임이 열리는지 확인.
  4. 서버로 전송된 최초 메타 메시지(JSON, `type: 'meta'`, `word_pk`, `word_name`) 확인 및 서버의 `meta_ack` 수신 확인.

- 녹화 흐름: 3초 카운트다운 + 5초 녹화
  1. `개인 학습 (3초 후 5초 녹화)` 버튼 클릭
     - 버튼 비활성화, 카운트다운 `3`→`2`→`1`→`START` 표시 확인.
     - 녹화 중 콘솔에 `[frame-send] #... size=... bytes` 로그 출력 확인 (프레임 Blob 전송).
     - 녹화 종료 후 `sendSaveLearning()`가 호출되어 `{ type: 'save_learning' }` 전송 확인.
     - 서버로부터 `learning_ack` 수신 시 UI(`serverFeedback`) 업데이트 확인.
  2. `퀴즈 (3초 후 5초 녹화)` 버튼 클릭
     - 동일한 카운트/녹화 흐름 확인 후 `sendFlush()`로 `{ type: 'flush' }` 전송 확인.
     - 서버의 `inference_result` 수신 시 결과 및 신뢰도 표시 확인.

- 오류/엣지케이스
  1. 카메라 권한 거부 상태에서 연결 시 `camError` 노출 및 동작 차단 확인.
  2. WebSocket 연결이 끊긴 상태에서 녹화 시작 시 경고 및 녹화 불가 확인.
  3. 개발자 콘솔에서 `wsSendMeta()`를 인자 없이 호출하면 예외가 발생하는지 확인(호출자 에러 처리 확인).

### 3. 검증 포인트 (로그 / 네트워크 / UI)
- 콘솔 로그
  - `frontend/src/services/signedu/signEduWebSocket.js` 로그: `(Cookie Auth via Proxy) Connecting to ...`, `✅ WebSocket Connected`, `RECV:`, `SEND (meta)`, `SEND (save_learning)`, `SEND (flush)` 등.
  - 프레임 전송 로그: `[frame-send] #<n> t=<ms> size=<bytes>`
- Network(DevTools) → WebSocket Frames
  - JSON 메시지(메타, save_learning, flush) 및 Blob(바이너리) 프레임 전송 확인.
- UI 상태
  - `wsStatus` 변화(Connecting → Connected → Disconnected) 확인.
  - 녹화 중 버튼 비활성화 및 녹화 후 재활성화 확인.
  - 카운트다운 텍스트(3→2→1→START) 표시 확인.
  - `serverFeedback`가 `meta_ack`, `learning_ack`, `inference_result`에 따라 업데이트되는지 확인.

---

## 셀프 체크리스트 (Self-Checklist)
> 리뷰 요청 전, 아래 항목을 확인해주세요.
- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [x] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)
> 리뷰어가 특별히 더 신경 써서 봐야 할 부분이나 참고사항을 작성해주세요.
> (예: 성능 최적화 부분 집중 검토 필요, API 스펙 변경 사항 확인 요청 등)

- `requestAnimationFrame`을 사용한 25fps 제한 로직이 의도대로 작동하는지 확인 부탁드립니다.
- `learn` 모드와 `quiz` 모드 분기 처리 및 `isBusy` 상태를 이용한 중복 클릭 방지 로직을 중점적으로 검토해 주시면 감사하겠습니다.
- 개발 환경 인증서 비밀번호가 변경되었으니 (`application-dev.yml`) 확인 필요합니다.