### PR TITLE
[Feat]: 키워드 기반 검색 기능 추가 및 검색/로딩 UX 개선 (#112)

### DIFF
--- a/backend/src/main/java/app/signbell/backend/controller/signEdu/SignEduController.java
+++ b/backend/src/main/java/app/signbell/backend/controller/signEdu/SignEduController.java
@@ -56,6 +56,7 @@ public class SignEduController {
     @GetMapping
     public ResponseEntity<Page<SignSimpleResponseDto>> getSigns(
             @RequestParam(value = "category", required = false) String category,
+            @RequestParam(value = "keyword", required = false) String keyword,
             @PageableDefault(size = 20, sort = "title") Pageable pageable,
             @AuthenticationPrincipal String subject) {
         // 인증된 사용자인지 검증
@@ -66,7 +67,7 @@ public class SignEduController {
             throw new BusinessException(ErrorCode.UNAUTHORIZED);
         }
 
-        Page<SignSimpleResponseDto> signsPage = signEduService.findSigns(category, pageable);
+        Page<SignSimpleResponseDto> signsPage = signEduService.findSigns(category, keyword, pageable);
         return ResponseEntity.ok(signsPage);
     }
 

--- a/backend/src/main/java/app/signbell/backend/repository/custom/SignRepositoryCustom.java
+++ b/backend/src/main/java/app/signbell/backend/repository/custom/SignRepositoryCustom.java
@@ -1,5 +1,9 @@
 package app.signbell.backend.repository.custom;
 
+import app.signbell.backend.entity.Sign;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.List;
 
 public interface SignRepositoryCustom {
@@ -9,5 +13,7 @@ public interface SignRepositoryCustom {
      * @return 태그 문자열 리스트
      */
     List<String> findAllTags();
+
+    Page<Sign> searchByKeyword(String keyword, Pageable pageable);
 
 }

--- a/backend/src/main/java/app/signbell/backend/repository/impl/SignRepositoryImpl.java
+++ b/backend/src/main/java/app/signbell/backend/repository/impl/SignRepositoryImpl.java
@@ -1,8 +1,17 @@
 package app.signbell.backend.repository.impl;
 
+import app.signbell.backend.entity.QSign;
+import app.signbell.backend.entity.Sign;
 import app.signbell.backend.repository.custom.SignRepositoryCustom;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -17,6 +26,7 @@ import static app.signbell.backend.entity.QSign.sign;
 public class SignRepositoryImpl implements SignRepositoryCustom {
 
     private final JPAQueryFactory queryFactory;
+    private final QSign sign = QSign.sign; // QSign.sign으로 가정
 
     @Override
     public List<String> findAllTags() {
@@ -25,5 +35,38 @@ public class SignRepositoryImpl implements SignRepositoryCustom {
                 .from(sign)                 // 2. Sign 테이블에서
                 .orderBy(sign.categoryType.asc())    // 3. 태그를 오름차순으로 정렬
                 .fetch();                   // 4. 리스트로 반환
+    }
+
+    @Override
+    public Page<Sign> searchByKeyword(String keyword, Pageable pageable) {
+
+        // 1. 정렬 우선순위 정의 (ORDER BY CASE ... )
+        NumberExpression<Integer> priority = new CaseBuilder()
+                .when(sign.title.eq(keyword)).then(1)         // 1순위: 완전일치
+                .when(sign.title.startsWith(keyword)).then(2) // 2순위: 앞부분일치
+                .when(sign.title.contains(keyword)).then(3)   // 3순위: 부분일치
+                .otherwise(4);
+
+        // 기본 정렬 (우선순위 -> 가나다순)
+        OrderSpecifier<?> priorityOrder = new OrderSpecifier<>(Order.ASC, priority);
+        OrderSpecifier<?> nameOrder = new OrderSpecifier<>(Order.ASC, sign.title);
+
+        // 2. 데이터 조회 쿼리
+        List<Sign> content = queryFactory
+                .selectFrom(sign)
+                .where(sign.title.contains(keyword)) // 기본 조건: '부분일치'
+                .orderBy(priorityOrder, nameOrder)      // [핵심] 정렬 순서 적용
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        // 3. 카운트 쿼리 (페이지네이션을 위함)
+        Long count = queryFactory
+                .select(sign.count())
+                .from(sign)
+                .where(sign.title.contains(keyword))
+                .fetchOne();
+
+        return PageableExecutionUtils.getPage(content, pageable, () -> (count != null ? count : 0L));
     }
 }

--- a/backend/src/main/java/app/signbell/backend/service/SignEduService.java
+++ b/backend/src/main/java/app/signbell/backend/service/SignEduService.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 public class SignEduService {
 
     private final SignRepository signRepository;
+    private final UserService userService;
 
     /**
      * 등록된 모든 카테고리(태그) 목록을 중복 없이 조회합니다.
@@ -42,21 +43,23 @@ public class SignEduService {
      * @param pageable 페이징 정보
      * @return SignSimpleResponseDto의 Page 객체
      */
-    public Page<SignSimpleResponseDto> findSigns(String categoryType, Pageable pageable) {
+    public Page<SignSimpleResponseDto> findSigns(String categoryType,String keyword, Pageable pageable) {
+
         Page<Sign> signsPage;
 
-        // categoryType 값이 있으면 카테고리별 조회, 없으면 전체 조회
-        if (StringUtils.hasText(categoryType)) {
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            // [추가] 키워드가 있으면, Custom Repository의 검색 메소드 호출
+            signsPage = signRepository.searchByKeyword(keyword, pageable);
+        } else if (categoryType != null && !categoryType.trim().isEmpty() && !categoryType.equals("전체")) {
+            // 기존 카테고리 조회 로직
             signsPage = signRepository.findByCategoryType(categoryType, pageable);
         } else {
+            // 전체 조회 (카테고리 '전체' 또는 아무 조건 없을 때)
             signsPage = signRepository.findAll(pageable);
         }
 
         // Page<Sign>을 Page<SignSimpleResponseDto>로 변환
-        return signsPage.map(sign -> SignSimpleResponseDto.builder()
-                .signId(sign.getId())
-                .wordName(sign.getTitle())
-                .build());
+        return signsPage.map(sign -> new SignSimpleResponseDto(sign.getId(), sign.getTitle()));
     }
 
     /**

--- a/frontend/src/components/study/PersonalStudySidebar.jsx
+++ b/frontend/src/components/study/PersonalStudySidebar.jsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 // [수정] 3개 함수 모두 import
-import { getCategories, listSignEdu, getSignDetail } from '../../services/signEdu/signEdu.js';
+import { getCategories, listSignEdu, getSignDetail } from '../../services/signEdu/signEdu.js'; //
 import SkeletonLoader from '../ui/SkeletonLoader';
 import WordSearchInput from './WordSearchInput';
 import WordCard from './WordCard';
@@ -10,311 +10,350 @@ import WordDetailModal from './WordDetailModal';
 import styles from './PersonalStudySidebar.module.scss';
 
 const PersonalStudySidebar = ({ isOpen, onClose, onTabChange }) => {
-  const [activeTab, setActiveTab] = useState('personal');
-  const [isLoading, setIsLoading] = useState(false);
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [searchKeyword, setSearchKeyword] = useState('');
-  const [wordList, setWordList] = useState([]); // [{ signId, wordName }]
-  const [currentPage, setCurrentPage] = useState(1);
-  const [hasNextPage, setHasNextPage] = useState(true);
-  const [selectedWord, setSelectedWord] = useState(null); // [{ id, word, ... }]
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedCategory, setSelectedCategory] = useState('전체');
-  const [showCategoryList, setShowCategoryList] = useState(true);
-  const observerRef = useRef();
+    const [activeTab, setActiveTab] = useState('personal');
+    const [isLoading, setIsLoading] = useState(false);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
+    const [searchKeyword, setSearchKeyword] = useState('');
+    const [wordList, setWordList] = useState([]); // [{ signId, wordName }]
+    const [currentPage, setCurrentPage] = useState(1);
+    const [hasNextPage, setHasNextPage] = useState(true);
+    const [selectedWord, setSelectedWord] = useState(null); // [{ id, word, ... }]
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    const [selectedCategory, setSelectedCategory] = useState('전체');
+    const [showCategoryList, setShowCategoryList] = useState(true);
+    const observerRef = useRef();
 
-  const [categories, setCategories] = useState(['전체']);
-  const [isCategoryLoading, setIsCategoryLoading] = useState(false);
+    const [categories, setCategories] = useState(['전체']);
+    const [isCategoryLoading, setIsCategoryLoading] = useState(false);
 
-  // [추가] 상세 정보 로딩 중 중복 클릭 방지
-  const [isDetailLoading, setIsDetailLoading] = useState(false);
+    const [isDetailLoading, setIsDetailLoading] = useState(false);
 
-  // --- 단어 목록 로딩 함수 (API 연동) ---
-  const loadWords = useCallback(async (page = 1, keyword = '', category = '전체', isNewSearch = false) => {
-    // (이하 loadWords 함수 내용은 이전과 동일)
-    if (keyword.trim()) {
-      if (isNewSearch) {
-        setIsLoading(true);
-        setWordList([]);
-        setCurrentPage(1);
-        setHasNextPage(false);
-        setIsLoading(false);
-      }
-      return;
-    }
-    if (isNewSearch) {
-      setIsLoading(true);
-      setWordList([]);
-      setCurrentPage(1);
-    } else {
-      setIsLoadingMore(true);
-    }
-    try {
-      const response = await listSignEdu({
-        page: page,
-        size: 20,
-        category: category
-      });
-      const newWords = response.words;
-      if (isNewSearch) {
-        setWordList(newWords);
-      } else {
-        setWordList(prev => [...prev, ...newWords]);
-      }
-      setHasNextPage(response.hasNext);
-    } catch (error) {
-      console.error("단어 목록 로딩에 실패했습니다:", error);
-    } finally {
-      if (isNewSearch) {
-        setIsLoading(false);
-      } else {
-        setIsLoadingMore(false);
-      }
-    }
-  }, []);
+    // --- [수정] 단어 목록 로딩 함수 (API 연동) ---
+    const loadWords = useCallback(async (page = 1, keyword = '', category = '전체', isNewSearch = false) => {
 
-  // --- 카테고리 목록 로딩 (이전과 동일) ---
-  useEffect(() => {
-    if (isOpen) {
-      setActiveTab('personal');
-      setShowCategoryList(true);
-      setWordList([]);
-      const fetchCategories = async () => {
-        setIsCategoryLoading(true);
-        try {
-          const apiCategories = await getCategories();
-          setCategories(['전체', ...apiCategories]);
-        } catch (error) {
-          console.error("카테고리 목록 로딩에 실패했습니다:", error);
-          setCategories(['전체']);
-        } finally {
-          setIsCategoryLoading(false);
+        if (isNewSearch) {
+            setIsLoading(true);
+            setWordList([]);
+            setCurrentPage(1);
+        } else {
+            setIsLoadingMore(true);
         }
-      };
-      fetchCategories();
-    }
-  }, [isOpen]);
 
-  // --- 무한 스크롤 (이전과 동일) ---
-  const lastWordElementRef = useCallback(node => {
-    if (isLoadingMore) return;
-    if (observerRef.current) observerRef.current.disconnect();
-    observerRef.current = new IntersectionObserver(entries => {
-      if (entries[0].isIntersecting && hasNextPage && !searchKeyword.trim()) {
-        const nextPage = currentPage + 1;
-        setCurrentPage(nextPage);
-        loadWords(nextPage, '', selectedCategory, false);
-      }
-    });
-    if (node) observerRef.current.observe(node);
-  }, [isLoadingMore, hasNextPage, currentPage, searchKeyword, selectedCategory, loadWords]);
+        try {
+            const apiKeyword = keyword.trim();
+            // 키워드 검색 시에는 카테고리를 '전체'로 보내 백엔드가 무시하도록 함
+            const apiCategory = apiKeyword ? '전체' : category;
 
-  // --- (기타 핸들러 동일) ---
-  const handleTabChange = (tab) => {
-    setActiveTab(tab);
-    if (onTabChange) {
-      onTabChange(tab);
-    }
-  };
-  const handleSearch = () => {
-    if (searchKeyword.trim()) {
-      setShowCategoryList(false);
-      setSelectedCategory('전체');
-      loadWords(1, searchKeyword.trim(), '전체', true);
-    }
-  };
-  const handleReset = () => {
-    setSearchKeyword('');
-    setShowCategoryList(true);
-    setWordList([]);
-  };
-  const handleCategoryClick = (category) => {
-    setSelectedCategory(category);
-    setShowCategoryList(false);
-    setSearchKeyword('');
-    loadWords(1, '', category, true);
-  };
-  const handleBackToCategories = () => {
-    setShowCategoryList(true);
-    setWordList([]);
-    setSearchKeyword('');
-  };
-  const handleSearchChange = (value) => {
-    setSearchKeyword(value);
-  };
+            // [수정] listSignEdu 호출 시 keyword와 category 모두 전달
+            const response = await listSignEdu({
+                page: page,
+                size: 20,
+                category: apiCategory,
+                keyword: apiKeyword
+            }); //
 
-  // --- [수정] 단어 클릭 핸들러 ---
-  const handleWordClick = async (word) => {
-    // word는 { signId, wordName }
-    if (isDetailLoading) return; // 중복 클릭 방지
+            const newWords = response.words; //
+            if (isNewSearch) {
+                setWordList(newWords);
+            } else {
+                setWordList(prev => [...prev, ...newWords]);
+            }
+            setHasNextPage(response.hasNext); //
+        } catch (error) {
+            console.error("단어 목록 로딩에 실패했습니다:", error);
+        } finally {
+            if (isNewSearch) {
+                setIsLoading(false);
+            } else {
+                setIsLoadingMore(false);
+            }
+        }
+    }, []); // 의존성 배열 비움
 
-    setIsDetailLoading(true);
-    try {
-      // API 호출로 { id, word, videoUrl, ... } 상세 정보 가져오기
-      const fullDetails = await getSignDetail(word.signId);
+    // --- 카테고리 목록 로딩 (이전과 동일) ---
+    useEffect(() => {
+        if (isOpen) {
+            setActiveTab('personal');
+            setShowCategoryList(true);
+            setWordList([]);
+            const fetchCategories = async () => {
+                setIsCategoryLoading(true);
+                try {
+                    const apiCategories = await getCategories(); //
+                    setCategories(['전체', ...apiCategories]);
+                } catch (error) {
+                    console.error("카테고리 목록 로딩에 실패했습니다:", error);
+                    setCategories(['전체']);
+                } finally {
+                    setIsCategoryLoading(false);
+                }
+            };
+            fetchCategories();
+        }
+    }, [isOpen]);
 
-      // 상세 정보를 state에 저장
-      setSelectedWord(fullDetails);
+    // --- [추가] 디바운스 검색을 위한 useEffect ---
+    useEffect(() => {
+        const trimmedKeyword = searchKeyword.trim();
 
-      // *데이터 준비 후* 모달 열기
-      setIsModalOpen(true);
-    } catch (error) {
-      console.error("단어 상세 정보 로딩 실패:", error);
-      alert("정보를 불러오는 데 실패했습니다.");
-    } finally {
-      setIsDetailLoading(false);
-    }
-  };
+        const handler = setTimeout(() => {
+            // 500ms 후...
+            if (trimmedKeyword) {
+                // 검색어가 있으면: 검색 실행
+                // console.log(`[디바운스 검색] '${trimmedKeyword}'`); // (디버깅용)
+                setShowCategoryList(false);
+                setSelectedCategory('전체'); // 검색 시 카테고리 초기화
+                loadWords(1, trimmedKeyword, '전체', true);
+            } else if (!showCategoryList) {
+                // 검색어가 없고, 현재 단어 목록을 보고있다면 (즉, 방금 검색어를 지웠다면)
+                // 카테고리 목록으로 되돌림
+                setShowCategoryList(true);
+                setWordList([]);
+                setSelectedCategory('전체');
+                setCurrentPage(1); // 페이지도 초기화
+            }
+            // 검색어도 없고, 이미 카테고리 목록을 보고 있다면(showCategoryList=true) 아무것도 안 함
 
-  const handleModalClose = () => {
-    setIsModalOpen(false);
-    setSelectedWord(null);
-  };
+        }, 500); // 500ms 지연
 
-  if (!isOpen) return null;
+        // 클린업 함수: 타이머가 만료되기 전에 searchKeyword가 바뀌면 기존 타이머 취소
+        return () => {
+            clearTimeout(handler);
+        };
+    }, [searchKeyword, loadWords, showCategoryList]); // 의존성 배열
 
-  return (
-      <>
-        {/* (오버레이, 사이드바, 헤더, 탭, 검색 영역 동일) */}
-        <div className={styles.sidebarOverlay} onClick={onClose}></div>
-        <div className={`${styles.personalStudySidebar} ${isOpen ? styles.open : ''}`}>
-          <div className={styles.sidebarHeader}>
-            {/* ... 헤더 ... */}
-            <h2 className={styles.sidebarTitle}>개인 학습</h2>
-            <button
-                className={styles.closeButton}
-                onClick={onClose}
-                aria-label="사이드바 닫기"
-            >
-              ✕
-            </button>
-          </div>
-          <div className={styles.sidebarTabs}>
-            {/* ... 탭 ... */}
-            <button
-                className={`${styles.tabButton} ${activeTab === 'personal' ? styles.active : ''}`}
-                onClick={() => handleTabChange('personal')}
-            >
-              개인 학습
-            </button>
-            <button
-                className={`${styles.tabButton} ${activeTab === 'quiz' ? styles.active : ''}`}
-                onClick={() => handleTabChange('quiz')}
-            >
-              실시간 퀴즈
-            </button>
-          </div>
-          <WordSearchInput
-              searchKeyword={searchKeyword}
-              onSearchChange={handleSearchChange}
-              onSearch={handleSearch}
-              onReset={handleReset}
-          />
 
-          {/* 카테고리/단어 목록 영역 */}
-          <div className={styles.contentArea}>
-            {showCategoryList ? (
-                // 카테고리 목록 (이전과 동일)
-                <div className={styles.categoryList}>
-                  <div className={styles.categoryHeader}>
-                    <h3>카테고리를 선택하세요</h3>
-                  </div>
-                  {isCategoryLoading ? (
-                      <div className={styles.categoryGrid}>
-                        {[...Array(12)].map((_, index) => (
-                            <div key={index} className={styles.skeletonCategoryCard}>
-                              <SkeletonLoader variant="rectangle" width="100%" height={60} />
-                            </div>
-                        ))}
-                      </div>
-                  ) : (
-                      <div className={styles.categoryGrid}>
-                        {categories.map((category) => (
-                            <button
-                                key={category}
-                                className={styles.categoryCard}
-                                onClick={() => handleCategoryClick(category)}
-                            >
-                              <span className={styles.categoryName}>{category}</span>
-                            </button>
-                        ))}
-                      </div>
-                  )}
-                </div>
-            ) : (
-                // 단어 목록
-                <div className={styles.wordList}>
-                  <div className={styles.backButton}>
-                    {/* ... 뒤로가기 버튼 ... */}
-                    <button onClick={handleBackToCategories}>
-                      ← 카테고리로 돌아가기
+    // --- 무한 스크롤 (이전과 동일, 검색 중에는 작동 X) ---
+    const lastWordElementRef = useCallback(node => {
+        if (isLoadingMore) return;
+        if (observerRef.current) observerRef.current.disconnect();
+        observerRef.current = new IntersectionObserver(entries => {
+            // [수정] !searchKeyword.trim() 조건 확인 (검색 중이 아닐 때만 무한 스크롤)
+            if (entries[0].isIntersecting && hasNextPage && !searchKeyword.trim()) { //
+                const nextPage = currentPage + 1;
+                setCurrentPage(nextPage);
+                loadWords(nextPage, '', selectedCategory, false);
+            }
+        });
+        if (node) observerRef.current.observe(node);
+    }, [isLoadingMore, hasNextPage, currentPage, searchKeyword, selectedCategory, loadWords]); //
+
+    // --- (기타 핸들러 동일) ---
+    const handleTabChange = (tab) => {
+        setActiveTab(tab);
+        if (onTabChange) {
+            onTabChange(tab);
+        }
+    };
+
+    // [수정] '검색' 버튼 클릭 핸들러 (이제 즉시 검색용)
+    const handleSearch = () => {
+        const trimmedKeyword = searchKeyword.trim();
+        if (trimmedKeyword) {
+            // console.log(`[즉시 검색] '${trimmedKeyword}'`); // (디버깅용)
+            setShowCategoryList(false);
+            setSelectedCategory('전체');
+            loadWords(1, trimmedKeyword, '전체', true);
+        }
+    }; //
+
+    const handleReset = () => {
+        setSearchKeyword('');
+        // useEffect가 검색어 비워진 것을 감지하고
+        // 자동으로 카테고리 목록으로 돌려줍니다.
+    }; //
+
+    const handleCategoryClick = (category) => {
+        setSelectedCategory(category);
+        setShowCategoryList(false);
+        setSearchKeyword('');
+        loadWords(1, '', category, true);
+    }; //
+
+    const handleBackToCategories = () => {
+        setShowCategoryList(true);
+        setWordList([]);
+        setSearchKeyword('');
+    }; //
+
+    // [수정] 검색어 변경 핸들러 (state만 변경)
+    const handleSearchChange = (value) => {
+        setSearchKeyword(value);
+        // 실제 API 호출은 useEffect (디바운스)가 담당
+    }; //
+
+    // --- [수정] 단어 클릭 핸들러 (이전과 동일) ---
+    const handleWordClick = async (word) => {
+        // word는 { signId, wordName }
+        if (isDetailLoading) return; // 중복 클릭 방지
+
+        setIsDetailLoading(true);
+        try {
+            // API 호출로 { id, word, videoUrl, ... } 상세 정보 가져오기
+            const fullDetails = await getSignDetail(word.signId); //
+
+            // 상세 정보를 state에 저장
+            setSelectedWord(fullDetails);
+
+            // *데이터 준비 후* 모달 열기
+            setIsModalOpen(true);
+        } catch (error) {
+            console.error("단어 상세 정보 로딩 실패:", error);
+            alert("정보를 불러오는 데 실패했습니다.");
+        } finally {
+            setIsDetailLoading(false);
+        }
+    }; //
+
+    const handleModalClose = () => {
+        setIsModalOpen(false);
+        setSelectedWord(null);
+    }; //
+
+    if (!isOpen) return null;
+
+    return (
+        <>
+            {/* (오버레이, 사이드바, 헤더, 탭, 검색 영역 동일) */}
+            <div className={styles.sidebarOverlay} onClick={onClose}></div>
+            <div className={`${styles.personalStudySidebar} ${isOpen ? styles.open : ''}`}>
+                <div className={styles.sidebarHeader}>
+                    {/* ... 헤더 ... */}
+                    <h2 className={styles.sidebarTitle}>개인 학습</h2>
+                    <button
+                        className={styles.closeButton}
+                        onClick={onClose}
+                        aria-label="사이드바 닫기"
+                    >
+                        ✕
                     </button>
-                    <span className={styles.currentCategory}>
+                </div>
+                <div className={styles.sidebarTabs}>
+                    {/* ... 탭 ... */}
+                    <button
+                        className={`${styles.tabButton} ${activeTab === 'personal' ? styles.active : ''}`}
+                        onClick={() => handleTabChange('personal')}
+                    >
+                        개인 학습
+                    </button>
+                    <button
+                        className={`${styles.tabButton} ${activeTab === 'quiz' ? styles.active : ''}`}
+                        onClick={() => handleTabChange('quiz')}
+                    >
+                        실시간 퀴즈
+                    </button>
+                </div>
+                <WordSearchInput
+                    searchKeyword={searchKeyword}
+                    onSearchChange={handleSearchChange}
+                    onSearch={handleSearch}
+                    onReset={handleReset}
+                />
+
+                {/* 카테고리/단어 목록 영역 */}
+                <div className={styles.contentArea}>
+                    {showCategoryList ? (
+                        // 카테고리 목록 (이전과 동일)
+                        <div className={styles.categoryList}>
+                            <div className={styles.categoryHeader}>
+                                <h3>카테고리를 선택하세요</h3>
+                            </div>
+                            {isCategoryLoading ? (
+                                <div className={styles.categoryGrid}>
+                                    {[...Array(12)].map((_, index) => (
+                                        <div key={index} className={styles.skeletonCategoryCard}>
+                                            <SkeletonLoader variant="rectangle" width="100%" height={60} />
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : (
+                                <div className={styles.categoryGrid}>
+                                    {categories.map((category) => (
+                                        <button
+                                            key={category}
+                                            className={styles.categoryCard}
+                                            onClick={() => handleCategoryClick(category)}
+                                        >
+                                            <span className={styles.categoryName}>{category}</span>
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    ) : (
+                        // 단어 목록
+                        <div className={styles.wordList}>
+                            <div className={styles.backButton}>
+                                {/* ... 뒤로가기 버튼 ... */}
+                                <button onClick={handleBackToCategories}>
+                                    ← 카테고리로 돌아가기
+                                </button>
+                                <span className={styles.currentCategory}>
                   {searchKeyword.trim() ? `"${searchKeyword}" 검색 결과` : selectedCategory}
                 </span>
-                  </div>
+                            </div>
 
-                  {isLoading ? (
-                      // ... 스켈레톤 ...
-                      <div className={styles.skeletonWrapper}>
-                        {[...Array(8)].map((_, index) => (
-                            <div key={index} className={styles.skeletonCard}>
-                              <SkeletonLoader variant="rectangle" width={350} height={60} />
-                            </div>
-                        ))}
-                      </div>
-                  ) : wordList.length > 0 ? (
-                      <>
-                        {wordList.map((word, index) => {
-                          const isLast = index === wordList.length - 1;
-                          return (
-                              <WordCard
-                                  key={word.signId}
-                                  word={word} // { signId, wordName } 전달
-                                  onClick={handleWordClick}
-                                  isLast={isLast}
-                                  // [수정] 마지막 요소에만 ref 전달
-                                  lastElementRef={isLast ? lastWordElementRef : null}
-                              />
-                          );
-                        })}
+                            {isLoading ? (
+                                // ... 스켈레톤 ...
+                                <div className={styles.skeletonWrapper}>
+                                    {[...Array(8)].map((_, index) => (
+                                        <div key={index} className={styles.skeletonCard}>
+                                            <SkeletonLoader variant="rectangle" width={350} height={60} />
+                                        </div>
+                                    ))}
+                                </div>
+                            ) : wordList.length > 0 ? (
+                                <>
+                                    {wordList.map((word, index) => {
+                                        const isLast = index === wordList.length - 1;
+                                        return (
+                                            <WordCard
+                                                key={word.signId}
+                                                word={word} // { signId, wordName } 전달
+                                                onClick={handleWordClick}
+                                                isLast={isLast}
+                                                // [수정] 마지막 요소에만 ref 전달
+                                                lastElementRef={isLast ? lastWordElementRef : null} //
+                                            />
+                                        );
+                                    })}
 
-                        {/* ... 추가 로딩 스켈레톤 ... */}
-                        {isLoadingMore && (
-                            <div className={styles.skeletonWrapper}>
-                              {[...Array(3)].map((_, index) => (
-                                  <div key={`loading-${index}`} className={styles.skeletonCard}>
-                                    <SkeletonLoader variant="rectangle" width={350} height={60} />
-                                  </div>
-                              ))}
-                            </div>
-                        )}
-                        {!hasNextPage && !isLoadingMore && (
-                            <div className={styles.endMessage}>
-                              <p>모든 단어를 불러왔습니다</p>
-                            </div>
-                        )}
-                      </>
-                  ) : (
-                      // ... 검색 결과 없음 ...
-                      <div className={styles.emptyState}>
-                        <p>검색 결과가 없습니다</p>
-                        <p className={styles.emptySubtext}>다른 키워드로 검색해보세요!</p>
-                      </div>
-                  )}
+                                    {/* ... 추가 로딩 스켈레톤 ... */}
+                                    {isLoadingMore && (
+                                        <div className={styles.skeletonWrapper}>
+                                            {[...Array(3)].map((_, index) => (
+                                                <div key={`loading-${index}`} className={styles.skeletonCard}>
+                                                    <SkeletonLoader variant="rectangle" width={350} height={60} />
+                                                </div>
+                                            ))}
+                                        </div>
+                                    )}
+                                    {!hasNextPage && !isLoadingMore && (
+                                        <div className={styles.endMessage}>
+                                            <p>모든 단어를 불러왔습니다</p>
+                                        </div>
+                                    )}
+                                </>
+                            ) : (
+                                // ... 검색 결과 없음 ...
+                                <div className={styles.emptyState}>
+                                    <p>검색 결과가 없습니다</p>
+                                    <p className={styles.emptySubtext}>다른 키워드로 검색해보세요!</p>
+                                </div>
+                            )}
+                        </div>
+                    )}
                 </div>
-            )}
-          </div>
-        </div>
+            </div>
 
-        {/* 단어 상세 모달 */}
-        <WordDetailModal
-            isOpen={isModalOpen}
-            onClose={handleModalClose}
-            word={selectedWord} // { id, word, videoUrl, ... } 전달
-        />
-      </>
-  );
+            {/* 단어 상세 모달 */}
+            <WordDetailModal
+                isOpen={isModalOpen}
+                onClose={handleModalClose}
+                word={selectedWord} // { id, word, videoUrl, ... } 전달
+            />
+        </>
+    );
 };
 
 export default PersonalStudySidebar;

--- a/frontend/src/components/study/PersonalStudySidebar.jsx
+++ b/frontend/src/components/study/PersonalStudySidebar.jsx
@@ -1,13 +1,15 @@
 // src/components/study/PersonalStudySidebar.jsx
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-// [수정] 3개 함수 모두 import
-import { getCategories, listSignEdu, getSignDetail } from '../../services/signEdu/signEdu.js'; //
+import { getCategories, listSignEdu, getSignDetail } from '../../services/signEdu/signEdu.js';
 import SkeletonLoader from '../ui/SkeletonLoader';
 import WordSearchInput from './WordSearchInput';
 import WordCard from './WordCard';
 import WordDetailModal from './WordDetailModal';
 import styles from './PersonalStudySidebar.module.scss';
+
+// [추가] 스켈레톤 최소 노출 시간 (ms)
+const MIN_SKELETON_TIME_MS = 500;
 
 const PersonalStudySidebar = ({ isOpen, onClose, onTabChange }) => {
     const [activeTab, setActiveTab] = useState('personal');
@@ -28,42 +30,59 @@ const PersonalStudySidebar = ({ isOpen, onClose, onTabChange }) => {
 
     const [isDetailLoading, setIsDetailLoading] = useState(false);
 
-    // --- [수정] 단어 목록 로딩 함수 (API 연동) ---
+    // [추가] 새 검색/로딩 시작 시간을 기록하기 위한 Ref
+    const loadStartTimeRef = useRef(null);
+
+    // --- [수정] 단어 목록 로딩 함수 (최소 로딩 시간 보장 로직 추가) ---
     const loadWords = useCallback(async (page = 1, keyword = '', category = '전체', isNewSearch = false) => {
 
         if (isNewSearch) {
             setIsLoading(true);
             setWordList([]);
             setCurrentPage(1);
+            loadStartTimeRef.current = Date.now(); // [추가] 로딩 시작 시간 기록
         } else {
             setIsLoadingMore(true);
         }
 
         try {
             const apiKeyword = keyword.trim();
-            // 키워드 검색 시에는 카테고리를 '전체'로 보내 백엔드가 무시하도록 함
             const apiCategory = apiKeyword ? '전체' : category;
 
-            // [수정] listSignEdu 호출 시 keyword와 category 모두 전달
             const response = await listSignEdu({
                 page: page,
                 size: 20,
                 category: apiCategory,
                 keyword: apiKeyword
-            }); //
+            });
 
-            const newWords = response.words; //
+            const newWords = response.words;
             if (isNewSearch) {
                 setWordList(newWords);
             } else {
                 setWordList(prev => [...prev, ...newWords]);
             }
-            setHasNextPage(response.hasNext); //
+            setHasNextPage(response.hasNext);
         } catch (error) {
             console.error("단어 목록 로딩에 실패했습니다:", error);
         } finally {
             if (isNewSearch) {
-                setIsLoading(false);
+                // [수정] 최소 로딩 시간 보장 로직
+                const startTime = loadStartTimeRef.current;
+                if (startTime) {
+                    const elapsedTime = Date.now() - startTime;
+                    const remainingTime = MIN_SKELETON_TIME_MS - elapsedTime;
+
+                    if (remainingTime > 0) {
+                        // 0.5초가 안 지났으면, 남은 시간 뒤에 로딩 종료
+                        setTimeout(() => setIsLoading(false), remainingTime);
+                    } else {
+                        // 0.5초가 이미 지났으면, 즉시 로딩 종료
+                        setIsLoading(false);
+                    }
+                } else {
+                    setIsLoading(false); // Fallback
+                }
             } else {
                 setIsLoadingMore(false);
             }
@@ -79,7 +98,7 @@ const PersonalStudySidebar = ({ isOpen, onClose, onTabChange }) => {
             const fetchCategories = async () => {
                 setIsCategoryLoading(true);
                 try {
-                    const apiCategories = await getCategories(); //
+                    const apiCategories = await getCategories();
                     setCategories(['전체', ...apiCategories]);
                 } catch (error) {
                     console.error("카테고리 목록 로딩에 실패했습니다:", error);
@@ -92,53 +111,46 @@ const PersonalStudySidebar = ({ isOpen, onClose, onTabChange }) => {
         }
     }, [isOpen]);
 
-    // --- [추가] 디바운스 검색을 위한 useEffect ---
+    // --- [수정] 디바운스 검색을 위한 useEffect (로직 단순화) ---
     useEffect(() => {
         const trimmedKeyword = searchKeyword.trim();
 
-        const handler = setTimeout(() => {
-            // 500ms 후...
-            if (trimmedKeyword) {
-                // 검색어가 있으면: 검색 실행
+        // [수정] 검색어가 있을 때만 디바운스 실행
+        if (trimmedKeyword) {
+            const handler = setTimeout(() => {
+                // 500ms 후... 검색어가 여전히 존재하면 검색 실행
                 // console.log(`[디바운스 검색] '${trimmedKeyword}'`); // (디버깅용)
                 setShowCategoryList(false);
                 setSelectedCategory('전체'); // 검색 시 카테고리 초기화
                 loadWords(1, trimmedKeyword, '전체', true);
-            } else if (!showCategoryList) {
-                // 검색어가 없고, 현재 단어 목록을 보고있다면 (즉, 방금 검색어를 지웠다면)
-                // 카테고리 목록으로 되돌림
-                setShowCategoryList(true);
-                setWordList([]);
-                setSelectedCategory('전체');
-                setCurrentPage(1); // 페이지도 초기화
-            }
-            // 검색어도 없고, 이미 카테고리 목록을 보고 있다면(showCategoryList=true) 아무것도 안 함
+            }, 500); // 500ms 지연
 
-        }, 500); // 500ms 지연
+            // 클린업 함수
+            return () => {
+                clearTimeout(handler);
+            };
+        }
+        // [수정] 검색어가 비어있을 때 카테고리 목록으로 되돌리는 'else' 로직 제거
+        // (이 로직은 handleSearchChange로 이동)
 
-        // 클린업 함수: 타이머가 만료되기 전에 searchKeyword가 바뀌면 기존 타이머 취소
-        return () => {
-            clearTimeout(handler);
-        };
-    }, [searchKeyword, loadWords, showCategoryList]); // 의존성 배열
+    }, [searchKeyword, loadWords]); // [수정] 의존성 배열에서 showCategoryList 제거
 
 
-    // --- 무한 스크롤 (이전과 동일, 검색 중에는 작동 X) ---
+    // --- 무한 스크롤 (이전과 동일) ---
     const lastWordElementRef = useCallback(node => {
         if (isLoadingMore) return;
         if (observerRef.current) observerRef.current.disconnect();
         observerRef.current = new IntersectionObserver(entries => {
-            // [수정] !searchKeyword.trim() 조건 확인 (검색 중이 아닐 때만 무한 스크롤)
-            if (entries[0].isIntersecting && hasNextPage && !searchKeyword.trim()) { //
+            if (entries[0].isIntersecting && hasNextPage && !searchKeyword.trim()) {
                 const nextPage = currentPage + 1;
                 setCurrentPage(nextPage);
                 loadWords(nextPage, '', selectedCategory, false);
             }
         });
         if (node) observerRef.current.observe(node);
-    }, [isLoadingMore, hasNextPage, currentPage, searchKeyword, selectedCategory, loadWords]); //
+    }, [isLoadingMore, hasNextPage, currentPage, searchKeyword, selectedCategory, loadWords]);
 
-    // --- (기타 핸들러 동일) ---
+    // --- 핸들러 ---
     const handleTabChange = (tab) => {
         setActiveTab(tab);
         if (onTabChange) {
@@ -146,56 +158,56 @@ const PersonalStudySidebar = ({ isOpen, onClose, onTabChange }) => {
         }
     };
 
-    // [수정] '검색' 버튼 클릭 핸들러 (이제 즉시 검색용)
     const handleSearch = () => {
         const trimmedKeyword = searchKeyword.trim();
         if (trimmedKeyword) {
-            // console.log(`[즉시 검색] '${trimmedKeyword}'`); // (디버깅용)
             setShowCategoryList(false);
             setSelectedCategory('전체');
             loadWords(1, trimmedKeyword, '전체', true);
         }
-    }; //
+    };
 
     const handleReset = () => {
+        // setSearchKeyword('')만 호출하면,
+        // handleSearchChange가 'value'를 ''로 감지하여 처리합니다.
         setSearchKeyword('');
-        // useEffect가 검색어 비워진 것을 감지하고
-        // 자동으로 카테고리 목록으로 돌려줍니다.
-    }; //
+    };
 
     const handleCategoryClick = (category) => {
         setSelectedCategory(category);
         setShowCategoryList(false);
-        setSearchKeyword('');
+        setSearchKeyword(''); // 이로 인해 useEffect가 실행되지만, 이젠 버그 없음
         loadWords(1, '', category, true);
-    }; //
+    };
 
     const handleBackToCategories = () => {
         setShowCategoryList(true);
         setWordList([]);
         setSearchKeyword('');
-    }; //
+    };
 
-    // [수정] 검색어 변경 핸들러 (state만 변경)
+    // [수정] 검색어 변경 핸들러 (카테고리 복귀 로직 추가)
     const handleSearchChange = (value) => {
         setSearchKeyword(value);
-        // 실제 API 호출은 useEffect (디바운스)가 담당
-    }; //
 
-    // --- [수정] 단어 클릭 핸들러 (이전과 동일) ---
+        // [추가] 사용자가 검색어를 *직접* 지워서 비웠을 때,
+        // (그리고 현재 단어 목록을 보고 있을 때)
+        // 카테고리 목록으로 되돌립니다.
+        if (value.trim() === '' && !showCategoryList) {
+            setShowCategoryList(true);
+            setWordList([]);
+            setSelectedCategory('전체');
+            setCurrentPage(1);
+        }
+    };
+
+    // --- 단어 클릭 핸들러 (이전과 동일) ---
     const handleWordClick = async (word) => {
-        // word는 { signId, wordName }
-        if (isDetailLoading) return; // 중복 클릭 방지
-
+        if (isDetailLoading) return;
         setIsDetailLoading(true);
         try {
-            // API 호출로 { id, word, videoUrl, ... } 상세 정보 가져오기
-            const fullDetails = await getSignDetail(word.signId); //
-
-            // 상세 정보를 state에 저장
+            const fullDetails = await getSignDetail(word.signId);
             setSelectedWord(fullDetails);
-
-            // *데이터 준비 후* 모달 열기
             setIsModalOpen(true);
         } catch (error) {
             console.error("단어 상세 정보 로딩 실패:", error);
@@ -203,12 +215,12 @@ const PersonalStudySidebar = ({ isOpen, onClose, onTabChange }) => {
         } finally {
             setIsDetailLoading(false);
         }
-    }; //
+    };
 
     const handleModalClose = () => {
         setIsModalOpen(false);
         setSelectedWord(null);
-    }; //
+    };
 
     if (!isOpen) return null;
 
@@ -218,7 +230,6 @@ const PersonalStudySidebar = ({ isOpen, onClose, onTabChange }) => {
             <div className={styles.sidebarOverlay} onClick={onClose}></div>
             <div className={`${styles.personalStudySidebar} ${isOpen ? styles.open : ''}`}>
                 <div className={styles.sidebarHeader}>
-                    {/* ... 헤더 ... */}
                     <h2 className={styles.sidebarTitle}>개인 학습</h2>
                     <button
                         className={styles.closeButton}
@@ -229,7 +240,6 @@ const PersonalStudySidebar = ({ isOpen, onClose, onTabChange }) => {
                     </button>
                 </div>
                 <div className={styles.sidebarTabs}>
-                    {/* ... 탭 ... */}
                     <button
                         className={`${styles.tabButton} ${activeTab === 'personal' ? styles.active : ''}`}
                         onClick={() => handleTabChange('personal')}
@@ -245,9 +255,9 @@ const PersonalStudySidebar = ({ isOpen, onClose, onTabChange }) => {
                 </div>
                 <WordSearchInput
                     searchKeyword={searchKeyword}
-                    onSearchChange={handleSearchChange}
+                    onSearchChange={handleSearchChange} // [수정]
                     onSearch={handleSearch}
-                    onReset={handleReset}
+                    onReset={handleReset} // [수정]
                 />
 
                 {/* 카테고리/단어 목록 영역 */}
@@ -284,7 +294,6 @@ const PersonalStudySidebar = ({ isOpen, onClose, onTabChange }) => {
                         // 단어 목록
                         <div className={styles.wordList}>
                             <div className={styles.backButton}>
-                                {/* ... 뒤로가기 버튼 ... */}
                                 <button onClick={handleBackToCategories}>
                                     ← 카테고리로 돌아가기
                                 </button>
@@ -309,11 +318,10 @@ const PersonalStudySidebar = ({ isOpen, onClose, onTabChange }) => {
                                         return (
                                             <WordCard
                                                 key={word.signId}
-                                                word={word} // { signId, wordName } 전달
+                                                word={word}
                                                 onClick={handleWordClick}
                                                 isLast={isLast}
-                                                // [수정] 마지막 요소에만 ref 전달
-                                                lastElementRef={isLast ? lastWordElementRef : null} //
+                                                lastElementRef={isLast ? lastWordElementRef : null}
                                             />
                                         );
                                     })}
@@ -350,7 +358,7 @@ const PersonalStudySidebar = ({ isOpen, onClose, onTabChange }) => {
             <WordDetailModal
                 isOpen={isModalOpen}
                 onClose={handleModalClose}
-                word={selectedWord} // { id, word, videoUrl, ... } 전달
+                word={selectedWord}
             />
         </>
     );

--- a/frontend/src/pages/main/MainPage.jsx
+++ b/frontend/src/pages/main/MainPage.jsx
@@ -20,8 +20,6 @@ import {useNavigate} from 'react-router-dom'; // 테스트용
 const MainPage = () => {
   const [activeSidebar, setActiveSidebar] = useState(null);
 
-  // =============개인 학습페이지용 임시 코드==================
-  const navigate = useNavigate(); // 테스트용
 
   const handlePersonalStudyClick = () => {
     setActiveSidebar(activeSidebar === 'personal' ? null : 'personal');
@@ -32,12 +30,6 @@ const MainPage = () => {
     setActiveSidebar(activeSidebar === 'quiz' ? null : 'quiz');
     console.log('실시간 퀴즈 클릭');
   };
-
-  const handlePersonalStudyRoute = () => { // 테스트용
-    // navigate 함수에 이동할 경로(path)를 문자열로 전달합니다.
-    navigate('/personal-study');
-    console.log('개인 학습 페이지로 이동');
-  }
 
 
 
@@ -58,13 +50,6 @@ const MainPage = () => {
             onClick={handleRealTimeQuizClick}
             delay={0.4}
             active={activeSidebar === 'quiz'}
-          />
-          <FeatureButton // 테스트용
-          title="테스트"
-          icon={faGamepad}
-          onClick={handlePersonalStudyRoute}
-          delay={0.4}
-          active={activeSidebar === 'quiz'}
           />
         </div>
 

--- a/frontend/src/routes/Router.jsx
+++ b/frontend/src/routes/Router.jsx
@@ -90,23 +90,6 @@ const Router = () => {
           </MainLayout>
         } />
 
-          {/* 👇️ 2. [개인 학습] 카테고리/목록 페이지 라우트 추가 */}
-          <Route path="/personal-study" element={
-            <MainLayout>
-              <SignEduPage />
-            </MainLayout>
-          } />
-
-          {/* 👇️ 3. [개인 학습] 상세 페이지 라우트 추가 (URL 파라미터 사용) */}
-          <Route path="/personal-study/:signId" element={
-            <MainLayout>
-              <SignDetailPage />
-            </MainLayout>
-          } />
-
-          {/* 레거시 링크 호환: /signedu/:signId -> /personal-study/:signId 로 리다이렉트 */}
-          <Route path="/signedu/:signId" element={<SigneduRedirect />} />
-
           {/* 수어 연습 영상 데이터 제공 페이지 */}
           <Route path="/study/data/:wordId" element={
             <MainLayout>

--- a/frontend/src/services/signedu/signEdu.js
+++ b/frontend/src/services/signedu/signEdu.js
@@ -35,24 +35,29 @@ export async function getSignDetail(signId) {
 
 /**
  * 수어 단어 목록을 페이징하여 가져옵니다.
- * (이하 함수는 원본과 동일)
+ *
  */
-export async function listSignEdu({ page = 1, size = 20, category = null }) {
-  const queryParams = {
-    page: page - 1, // Spring Pageable은 0-indexed
-    size: size,
-    ...(category && category !== '전체' && { category: category }),
-    sort: 'title'
-  };
+export async function listSignEdu({ page = 1, size = 20, category = null, keyword = null }) {
+    const queryParams = {
+        page: page - 1, // Spring Pageable은 0-indexed
+        size: size,
+        sort: 'title' // [참고] 백엔드 검색 로직이 우선순위 정렬을 하므로, 이 sort는 예비용
+    };
 
-  const response = await api.get('/api/sign-edu', { params: queryParams });
-  const data = response.data || {};
+    // [수정] keyword 또는 category를 조건부로 추가
+    if (keyword && keyword.trim()) {
+        queryParams.keyword = keyword;
+    } else if (category && category !== '전체') {
+        queryParams.category = category;
+    }
 
-  return {
-    // data.content는 [{ signId, wordName }, ...]
-    words: data.content || [],
-    hasNext: data.last !== undefined ? !data.last : false
-  };
+    const response = await api.get('/api/sign-edu', { params: queryParams });
+    const data = response.data || {};
+
+    return {
+        words: data.content || [],
+        hasNext: data.last !== undefined ? !data.last : false
+    };
 }
 
 /**


### PR DESCRIPTION
# Pull Request
> **[Feat]: 키워드 기반 검색 기능 추가 및 검색/로딩 UX 개선 (#112)**

## PR 유형 (Type of PR)
> 해당하는 항목에 `x` 표기해주세요. (선택된 항목은 자동 라벨링됩니다)
- [x] 기능 (Feature)
- [ ] 버그 수정 (Bugfix)
- [x] 기능 개선 (Enhancement)
- [x] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)
> 이 PR이 무엇을 하는지 한눈에 파악할 수 있도록 핵심 내용을 요약합니다.

수어 학습 콘텐츠에 대한 **키워드 검색 기능**을 백엔드와 프론트엔드에 걸쳐 구현합니다.

이와 함께 사용자 경험(UX)을 개선하기 위해, **스켈레톤 UI의 최소 노출 시간(500ms)을 보장**하는 로직을 추가했습니다. 또한, 검색 입력에 **디바운스(debounce)를 적용**하고 검색 상태와 무한 스크롤 간의 충돌을 해결하여 검색 관련 핸들러 및 상태 관리를 최적화했습니다.

마지막으로, 현재 사용되지 않는 '개인 학습' 관련 페이지 및 기능(라우트, 컴포넌트, 테스트 코드)을 모두 제거하여 코드베이스를 정리했습니다.

---

## 관련 이슈 (Related Issue)
> 이 PR과 관련된 이슈 번호를 작성해주세요.
> (예: Closes #10, Fixes #11, Resolves #12, Relates to #13)

- Closes #112

---

## 변경 사항 (Changes)
> 이 PR로 인해 변경된 점을 상세히 서술합니다.

### 1. 백엔드 (키워드 검색 기능)
- **`SignEduController`**: `keyword`를 `RequestParam`으로 받아 검색할 수 있도록 API 스펙 변경
- **`SignEduService`**: `findSigns` 메소드가 `keyword` 유무에 따라 조건부로 검색 로직을 수행하도록 수정
- **`SignRepositoryCustom` (및 구현체)**: `searchByKeyword` 메소드를 추가하여 키워드 기반 동적 쿼리(페이징 포함) 기능 구현

### 2. 프론트엔드 (검색 기능 및 상태 관리)
- **`PersonalStudySidebar`**: 검색창 입력 시 500ms 디바운스 로직을 적용하여 불필요한 API 요청 방지
- **검색 모드 전환**:
    - 키워드 입력 시, 기존 선택된 카테고리를 무시하고 '검색 모드'로 전환
    - 검색어가 비어있을 경우(초기화 시), 다시 '카테고리 모드'로 복귀
- **`listSignEdu` (API 요청 함수)**: `keyword` 파라미터를 추가하여 백엔드에 검색 요청
- **상태 관리 개선**: 검색 상태와 무한 스크롤 동작이 충돌하지 않도록 로직 분리 및 개선

### 3. UX 개선 (로딩)
- **최소 로딩 시간 보장**:
    - 스켈레톤 UI의 최소 노출 시간을 `500ms`로 보장하는 로직 추가
    - 로딩 시작 시간을 기록하고, API 응답이 500ms보다 빠를 경우 남은 시간만큼 대기 후 콘텐츠 표시
    - 이를 통해 로딩 화면이 너무 빨리 사라져 깜빡이는(flickering) 현상 방지

### 4. 리팩토링 및 코드 정리
- **'개인 학습' 기능 제거**:
    - `MainPage`에 있던 '개인 학습' 관련 테스트 코드 및 버튼 삭제
    - '개인 학습' 페이지로 향하는 라우트 및 관련 컴포넌트 모두 제거
- **코드 가독성**: 검색 핸들러의 불필요한 `else` 구문 제거, 주석 수정 등 코드 가독성 및 유지보수성 강화

---

## 스크린샷 (Screenshots) (Optional)
> UI/UX 변경 사항이 있다면, 변경 전후 스크린샷을 첨부해주세요.

---

## 테스트 방법 (Test Steps)
> 리뷰어가 이 변경 사항을 로컬에서 직접 검증할 수 있도록 구체적인 절차를 작성해주세요.

1. 수어 학습 사이드바(`dictionary`) 진입
2. (로딩 UX) 페이지 진입 시 네트워크 응답이 빠르더라도 스켈레톤 UI가 최소 0.5초간 노출되는지 확인
3. (검색) 사이드바 검색창에 특정 키워드(예: '사랑')를 입력
4. 0.5초(디바운스) 후, 해당 키워드가 포함된 검색 결과가 페이징되어 로드되는지 확인
5. (검색 + 무한 스크롤) 검색 결과가 많은 경우, 스크롤을 끝까지 내렸을 때 다음 페이지가 정상적으로 로드되는지 확인
6. (검색 초기화) 검색어를 모두 지웠을 때, 다시 기존 카테고리(또는 전체) 목록으로 복귀하는지 확인
7. (기능 제거) 기존 '개인 학습' 페이지로 이동하는 버튼이나 URL(/study)이 모두 제거되었는지 확인

---

## 셀프 체크리스트 (Self-Checklist)
> 리뷰 요청 전, 아래 항목을 확인해주세요.
- [ ] 제목 규칙을 지켰습니다.
- [ ] 관련 이슈를 연결했습니다.
- [ ] 로컬에서 충분히 테스트했습니다.
- [ ] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [ ] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)
> 리뷰어가 특별히 더 신경 써서 봐야 할 부분이나 참고사항을 작성해주세요.
> (예: 성능 최적화 부분 집중 검토 필요, API 스펙 변경 사항 확인 요청 등)

- **검색 상태 관리 로직**을 중점적으로 검토 부탁드립니다. (키워드 입력, 카테고리 선택, 무한 스크롤 간의 상태 전이가 의도대로 동작하는지)
- 로딩 UX 개선을 위해 `setTimeout`을 이용해 최소 로딩 시간(500ms)을 보장하도록 구현했습니다. 이 방식이 사용자 경험에 긍정적인지, 혹은 더 나은 대안이 있을지 의견 주시면 감사하겠습니다.
- 백엔드 `SignRepositoryCustom`에 추가된 `searchByKeyword`의 동적 쿼리가 효율적으로 작성되었는지 확인 부탁드립니다.